### PR TITLE
Fix for RFC 1214

### DIFF
--- a/crates/joker/src/track.rs
+++ b/crates/joker/src/track.rs
@@ -92,7 +92,7 @@ impl<T: FromStr> FromStr for Tracked<T> {
     }
 }
 
-pub trait IntoTracked {
+pub trait IntoTracked: Sized {
     fn tracked(self, Option<Span>) -> Tracked<Self>;
     //fn tracked<T: Track>(self, T) -> Tracked<Self>;
 }


### PR DESCRIPTION
Hi!

This PR contains fixes for breakage due to [RFC 1214]. These changes
will hit stable Rust in version 1.7, released on March 3. This patch
should be compatible with both 1.7 and 1.6. Your crate was identified
as being broken by the upcoming release in a recent crater [regression
test]. For more details about how we're responding to this breakage
see [this previous announcement]. To reduce the impact to your
downstream users I suggest publishing a new revision containing this
patch prior to the 1.7 release.

[this previous announcement]: https://users.rust-lang.org/t/upcoming-breakage-starting-in-rust-1-7-from-rfcs-1214-and-136/4207
[RFC 1214]: https://github.com/rust-lang/rfcs/blob/master/text/1214-projections-lifetimes-and-wf.md
[regression test]: https://internals.rust-lang.org/t/regression-report-stable-2016-01-21-vs-beta-2016-02-04/3171