### PR TITLE
Add benchmark support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,13 @@ rustc-test = "0.1"
 glob = "0.2"
 
 [[test]]
-name = "parser"
+name = "parser-test"
 harness = false
-bench = true
+
+[[bench]]
+name = "parser-bench"
+harness = false
+test = true
 
 [workspace]
 # Implicitly crawled from dependencies.*.path

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ glob = "0.2"
 [[test]]
 name = "parser"
 harness = false
+bench = true
 
 [workspace]
 # Implicitly crawled from dependencies.*.path

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,11 @@ glob = "0.2"
 name = "parser-test"
 harness = false
 
+[profile.bench]
+# It makes little sense to run cross-crate benchmarks w/o lto
+# (difference is significant)
+lto = true
+
 [[bench]]
 name = "parser-bench"
 harness = false

--- a/benches/parser-bench.rs
+++ b/benches/parser-bench.rs
@@ -4,7 +4,12 @@ extern crate esprit;
 extern crate estree;
 extern crate joker;
 extern crate serde_json;
+
+// From 'rustc-test' crate.
+// Mirrors Rust's internal 'libtest'.
+// https://doc.rust-lang.org/1.1.0/test/index.html
 extern crate test;
+
 extern crate unjson;
 
 use esprit::script;

--- a/benches/parser-bench.rs
+++ b/benches/parser-bench.rs
@@ -41,22 +41,6 @@ fn add_bench<F: Fn(&mut Bencher) + Send + 'static>(tests: &mut Vec<TestDescAndFn
     });
 }
 
-const DEFAULT_MB: usize = 4;
-
-fn stack_size() -> usize {
-    match env::var("ESTREE_STACK_SIZE_MB") {
-        Ok(s) => match s.parse() {
-            Ok(x) => Some(x),
-            Err(_) => None
-        },
-        Err(env::VarError::NotPresent) => Some(DEFAULT_MB),
-        Err(_) => None
-    }.unwrap_or_else(|| {
-        println!("warning: invalid ESTREE_STACK_SIZE_MB value; defaulting to {}MB", DEFAULT_MB);
-        DEFAULT_MB
-    }) * 1024 * 1024
-}
-
 fn integration_tests(target: &mut Vec<TestDescAndFn>, ignore: bool) {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
 
@@ -123,9 +107,9 @@ fn main() {
     if ignore_integration_tests {
         println!("note: Run with `ESTREE_INTEGRATION_TESTS=1` to run with integration tests (much slower).");
     }
-    thread::Builder::new().stack_size(stack_size()).spawn(move || {
+    thread::spawn(move || {
         let mut tests = Vec::new();
         integration_tests(&mut tests, ignore_integration_tests);
         test_main(&args, tests);
-    }).unwrap().join().unwrap();
+    }).join().unwrap();
 }

--- a/benches/parser-bench.rs
+++ b/benches/parser-bench.rs
@@ -1,0 +1,129 @@
+#![cfg(test)]
+
+extern crate esprit;
+extern crate estree;
+extern crate joker;
+extern crate serde_json;
+extern crate test;
+extern crate unjson;
+
+use esprit::script;
+use estree::IntoScript;
+use joker::track::Untrack;
+use serde_json::value::Value;
+use std::ffi::OsStr;
+use std::fs::{File, read_dir};
+use std::io::{Read, Write, stdout};
+use std::path::Path;
+use std::{thread, env};
+use test::{TestDesc, TestDescAndFn, TestName, TestFn, Bencher, TDynBenchFn, test_main};
+use test::ShouldPanic::No;
+use unjson::Unjson;
+
+struct DynBenchFn<F> {
+    run: F
+}
+
+impl<F: Fn(&mut Bencher) + Send + 'static> TDynBenchFn for DynBenchFn<F> {
+    fn run(&self, harness: &mut Bencher) {
+        (self.run)(harness);
+    }
+}
+
+fn add_bench<F: Fn(&mut Bencher) + Send + 'static>(tests: &mut Vec<TestDescAndFn>, name: String, ignore: bool, f: F) {
+    tests.push(TestDescAndFn {
+        desc: TestDesc {
+            name: TestName::DynTestName(name),
+            ignore: ignore,
+            should_panic: No
+        },
+        testfn: TestFn::DynBenchFn(Box::new(DynBenchFn { run: f }))
+    });
+}
+
+const DEFAULT_MB: usize = 4;
+
+fn stack_size() -> usize {
+    match env::var("ESTREE_STACK_SIZE_MB") {
+        Ok(s) => match s.parse() {
+            Ok(x) => Some(x),
+            Err(_) => None
+        },
+        Err(env::VarError::NotPresent) => Some(DEFAULT_MB),
+        Err(_) => None
+    }.unwrap_or_else(|| {
+        println!("warning: invalid ESTREE_STACK_SIZE_MB value; defaulting to {}MB", DEFAULT_MB);
+        DEFAULT_MB
+    }) * 1024 * 1024
+}
+
+fn integration_tests(target: &mut Vec<TestDescAndFn>, ignore: bool) {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    let fixtures = {
+        let mut fixtures = root.to_path_buf();
+        fixtures.push("tests");
+        fixtures.push("esprima");
+        fixtures.push("test");
+        fixtures.push("3rdparty");
+        fixtures
+    };
+
+    let syntax = fixtures.join("syntax");
+
+    let files =
+        read_dir(syntax).unwrap()
+        .map(|dir| dir.unwrap().path())
+        .filter(|path| path.extension() == Some(OsStr::new("json")))
+        .map(|tree_path| {
+            let mut source_path_buf = fixtures.join(tree_path.file_name().unwrap());
+            source_path_buf.set_extension("js");
+            (tree_path, source_path_buf)
+        });
+
+    for (tree_path, source_path) in files {
+        let name = source_path.strip_prefix(&root).unwrap().to_str().unwrap().to_string();
+        if !ignore {
+            let mut source = String::new();
+            File::open(source_path.clone()).unwrap().read_to_string(&mut source).unwrap();
+            print!("Parsing JSON {}...", tree_path.strip_prefix(&root).unwrap().to_str().unwrap());
+            stdout().flush().unwrap();
+            let expected_ast = thread::Builder::new().stack_size(stack_size()).spawn(|| {
+                let v: Value = serde_json::de::from_reader(File::open(tree_path).unwrap()).unwrap();
+                v.into_object().unwrap().into_script().map_err(|err| {
+                    format!("failed to deserialize script: {}", err)
+                }).unwrap()
+            }).unwrap().join().unwrap();
+            println!(" done");
+            add_bench(target, name, ignore, move |mut bench| {
+                let mut result = None;
+                bench.iter(|| {
+                    result = Some(script(&source[..]))
+                });
+                match result.unwrap() {
+                    Ok(mut actual_ast) => {
+                        actual_ast.untrack();
+                        assert!(actual_ast == expected_ast, "integration test got wrong result");
+                    }
+                    Err(actual_err) => {
+                        panic!("integration test failed to parse:\n{:#?}", actual_err);
+                    }
+                }
+            });
+        } else {
+            add_bench(target, name, ignore, |_| {});
+        }
+    }
+}
+
+fn main() {
+    let args: Vec<_> = env::args().collect();
+    let bench = args.contains(&"--bench".to_string());
+    let mut tests = Vec::new();
+    let ignore_integration_tests = !bench && env::var_os("ESTREE_INTEGRATION_TESTS") == None;
+    if ignore_integration_tests {
+        println!("note: Run with `ESTREE_INTEGRATION_TESTS=1` to run with integration tests (much slower).");
+    }
+    integration_tests(&mut tests, ignore_integration_tests);
+    test_main(&args, tests);
+}

--- a/tests/parser-test.rs
+++ b/tests/parser-test.rs
@@ -17,12 +17,11 @@ use estree::IntoScript;
 use glob::glob;
 use joker::track::Untrack;
 use serde_json::value::Value;
-use std::ffi::OsStr;
 use std::fs::{File, read_dir};
-use std::io::{Read, Write, stdout};
+use std::io::Read;
 use std::path::Path;
-use std::{thread, env};
-use test::{TestDesc, TestDescAndFn, TestName, TestFn, Bencher, TDynBenchFn, test_main};
+use std::env;
+use test::{TestDesc, TestDescAndFn, TestName, TestFn, test_main};
 use test::ShouldPanic::No;
 use unjson::{ExtractField, Unjson};
 
@@ -37,27 +36,6 @@ fn add_test<F: FnOnce() + Send + 'static>(tests: &mut Vec<TestDescAndFn>, name: 
     });
 }
 
-struct DynBenchFn<F> {
-    run: F
-}
-
-impl<F: Fn(&mut Bencher) + Send + 'static> TDynBenchFn for DynBenchFn<F> {
-    fn run(&self, harness: &mut Bencher) {
-        (self.run)(harness);
-    }
-}
-
-fn add_bench<F: Fn(&mut Bencher) + Send + 'static>(tests: &mut Vec<TestDescAndFn>, name: String, ignore: bool, f: F) {
-    tests.push(TestDescAndFn {
-        desc: TestDesc {
-            name: TestName::DynTestName(name),
-            ignore: ignore,
-            should_panic: No
-        },
-        testfn: TestFn::DynBenchFn(Box::new(DynBenchFn { run: f }))
-    });
-}
-
 fn as_ref_test(tests: &mut Vec<TestDescAndFn>) {
     add_test(tests, "reference test".to_string(), false, || {
         let mut ast = script("foobar = 17;").unwrap();
@@ -69,91 +47,6 @@ fn as_ref_test(tests: &mut Vec<TestDescAndFn>) {
             _ => { panic!("unexpected AST structure"); }
         }
     });
-}
-
-const DEFAULT_MB: usize = 4;
-
-fn read_envvar() -> Option<usize> {
-    match env::var("ESTREE_STACK_SIZE_MB") {
-        Ok(s) => {
-            match s.parse() {
-                Ok(x) => Some(x),
-                Err(_) => None
-            }
-        }
-        Err(env::VarError::NotPresent) => Some(DEFAULT_MB),
-        Err(_) => None
-    }
-}
-
-fn stack_size() -> usize {
-    let mb = match read_envvar() {
-        Some(x) => x,
-        None => {
-            println!("warning: invalid ESTREE_STACK_SIZE_MB value; defaulting to 4MB");
-            DEFAULT_MB
-        }
-    };
-    mb * 1024 * 1024
-}
-
-fn integration_tests(target: &mut Vec<TestDescAndFn>, ignore: bool) {
-    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
-
-    let fixtures = {
-        let mut fixtures = root.to_path_buf();
-        fixtures.push("tests");
-        fixtures.push("esprima");
-        fixtures.push("test");
-        fixtures.push("3rdparty");
-        fixtures
-    };
-
-    let syntax = fixtures.join("syntax");
-
-    let files =
-        read_dir(syntax).unwrap()
-        .map(|dir| dir.unwrap().path())
-        .filter(|path| path.extension() == Some(OsStr::new("json")))
-        .map(|tree_path| {
-            let mut source_path_buf = fixtures.join(tree_path.file_name().unwrap());
-            source_path_buf.set_extension("js");
-            (tree_path, source_path_buf)
-        });
-
-    for (tree_path, source_path) in files {
-        let name = source_path.strip_prefix(&root).unwrap().to_str().unwrap().to_string();
-        if !ignore {
-            let mut source = String::new();
-            File::open(source_path.clone()).unwrap().read_to_string(&mut source).unwrap();
-            print!("Parsing JSON {}...", tree_path.strip_prefix(&root).unwrap().to_str().unwrap());
-            stdout().flush().unwrap();
-            let expected_ast = thread::Builder::new().stack_size(stack_size()).spawn(|| {
-                let v: Value = serde_json::de::from_reader(File::open(tree_path).unwrap()).unwrap();
-                v.into_object().unwrap().into_script().map_err(|err| {
-                    format!("failed to deserialize script: {}", err)
-                }).unwrap()
-            }).unwrap().join().unwrap();
-            println!(" done");
-            add_bench(target, name, ignore, move |mut bench| {
-                let mut result = None;
-                bench.iter(|| {
-                    result = Some(script(&source[..]))
-                });
-                match result.unwrap() {
-                    Ok(mut actual_ast) => {
-                        actual_ast.untrack();
-                        assert!(actual_ast == expected_ast, "integration test got wrong result");
-                    }
-                    Err(actual_err) => {
-                        panic!("integration test failed to parse:\n{:#?}", actual_err);
-                    }
-                }
-            });
-        } else {
-            add_bench(target, name, ignore, |_| {});
-        }
-    }
 }
 
 fn unit_tests(target: &mut Vec<TestDescAndFn>) {
@@ -231,16 +124,8 @@ fn unit_tests(target: &mut Vec<TestDescAndFn>) {
 
 fn main() {
     let args: Vec<_> = env::args().collect();
-    let bench = args.contains(&"--bench".to_string());
     let mut tests = Vec::new();
-    if !bench {
-        as_ref_test(&mut tests);
-        unit_tests(&mut tests);
-    }
-    let ignore_integration_tests = !bench && env::var_os("ESTREE_INTEGRATION_TESTS") == None;
-    if ignore_integration_tests {
-        println!("note: Run with `ESTREE_INTEGRATION_TESTS=1` to run with integration tests (much slower).");
-    }
-    integration_tests(&mut tests, ignore_integration_tests);
+    as_ref_test(&mut tests);
+    unit_tests(&mut tests);
     test_main(&args, tests);
 }

--- a/tests/parser-test.rs
+++ b/tests/parser-test.rs
@@ -6,7 +6,12 @@ extern crate estree;
 extern crate glob;
 extern crate joker;
 extern crate serde_json;
+
+// From 'rustc-test' crate.
+// Mirrors Rust's internal 'libtest'.
+// https://doc.rust-lang.org/1.1.0/test/index.html
 extern crate test;
+
 extern crate unjson;
 
 use easter::expr::Expr;

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -126,7 +126,7 @@ fn integration_tests(target: &mut Vec<TestDescAndFn>, ignore: bool) {
         if !ignore {
             let mut source = String::new();
             File::open(source_path.clone()).unwrap().read_to_string(&mut source).unwrap();
-            print!("Parsing JSON {:?}...", tree_path);
+            print!("Parsing JSON {}...", tree_path.strip_prefix(&root).unwrap().to_str().unwrap());
             stdout().flush().unwrap();
             let expected_ast = thread::Builder::new().stack_size(stack_size()).spawn(|| {
                 let v: Value = serde_json::de::from_reader(File::open(tree_path).unwrap()).unwrap();


### PR DESCRIPTION
Use integration tests as benchmark fixtures (usable with `cargo bench`).