### PR TITLE
Add performance comparison of PR to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,8 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
+install:
+  - cargo benchcmp --version || cargo install cargo-benchcmp
+cache: cargo
+after_script:
+  - ./travis-after-script.sh

--- a/travis-after-script.sh
+++ b/travis-after-script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+    # Bench variable
+    echo "Benchmarking PR #$TRAVIS_PULL_REQUEST..." && \
+    cargo bench > benches/PR_$TRAVIS_PULL_REQUEST && \
+    # Bench master
+    echo "Checking out $TRAVIS_BRANCH..." && \
+    git remote set-branches origin $TRAVIS_BRANCH && \
+    git fetch origin $TRAVIS_BRANCH && \
+    git checkout $TRAVIS_BRANCH && \
+    echo "Benchmarking $TRAVIS_BRANCH" && \
+    cargo bench > benches/$TRAVIS_BRANCH && \
+    echo "Performance comparison:" && \
+    cd benches && \
+    cargo benchcmp $TRAVIS_BRANCH PR_$TRAVIS_PULL_REQUEST;
+fi


### PR DESCRIPTION
This PR is a self-hosted demonstration of benchmark comparison on new PRs that can be seen in Travis logs (helps to find out if any specific PR introduces significant performance regressions in suspicious cases such as #26).