### PR TITLE
Custom derives for tracking traits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,7 @@ matrix:
 install:
   - cargo benchcmp --version || cargo install cargo-benchcmp
 cache: cargo
+script:
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo test --features nightly; else cargo test; fi
 after_script:
   - ./travis-after-script.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ homepage = "https://esprit.surge.sh"
 repository = "https://github.com/dherman/esprit"
 exclude = ["tests/esprima/**/*"]
 
+[features]
+nightly = ["easter/nightly"]
+
 [dependencies]
 serde = "0.8"
 serde_json = "0.8"

--- a/crates/derive-context/Cargo.toml
+++ b/crates/derive-context/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "derive-context"
+version = "0.0.1"
+authors = ["Ingvar Stepanyan <me@rreverser.com>"]
+publish = false
+
+[dependencies]
+syn = { version = "0.10.5", features = ["expand"] }
+quote = "0.3.10"

--- a/crates/derive-context/src/lib.rs
+++ b/crates/derive-context/src/lib.rs
@@ -1,0 +1,257 @@
+extern crate syn;
+
+#[macro_use]
+extern crate quote;
+
+use std::iter;
+pub use syn::*;
+use quote::Tokens;
+
+pub struct Context {
+    location_ident: Ident,
+    location_expr: Expr,
+    location_type: Ty,
+    deref_self_expr: Expr,
+}
+
+impl Context {
+    pub fn new() -> Self {
+        Context {
+            location_ident: Ident::from("location"),
+
+            location_expr: Expr::from(ExprKind::Path(None, Path::from("location"))),
+
+            location_type: Ty::Path(None, Path {
+                global: false,
+                segments: vec![PathSegment {
+                    ident: Ident::from("Option"),
+                    parameters: PathParameters::AngleBracketed(AngleBracketedParameterData {
+                        lifetimes: vec![],
+                        types: vec![Ty::Path(None, Path::from("Span"))],
+                        bindings: vec![]
+                    })
+                }]
+            }),
+
+            deref_self_expr: Expr::from(ExprKind::Unary(
+                UnOp::Deref,
+                Box::new(Expr::from(ExprKind::Path(None, Path::from("self"))))
+            ))
+        }
+    }
+
+    fn expand_tracking_data(&self, path: Path, data: &VariantData, mutability: Mutability) -> Arm {
+        let location_pat = Pat::Ident(BindingMode::ByRef(mutability), self.location_ident.clone(), None);
+
+        let expr = self.location_expr.clone();
+
+        let (pat, expr) = match *data {
+            VariantData::Struct(_) => (
+                Pat::Struct(path, vec![FieldPat {
+                    ident: self.location_ident.clone(),
+                    pat: Box::new(location_pat),
+                    is_shorthand: true
+                }], true),
+                if data.fields().iter().any(|field| field.ident.as_ref() == Some(&self.location_ident) && field.ty == self.location_type) {
+                    expr
+                } else {
+                    panic!("Struct does not containt `location: Option<Span>`")
+                }
+            ),
+            VariantData::Tuple(ref fields) => (
+                Pat::TupleStruct(path, {
+                    let mut v = Vec::with_capacity(fields.len());
+                    v.push(location_pat);
+                    v.extend(iter::repeat(Pat::Wild).take(fields.len() - 1));
+                    v
+                }, None),
+                if data.fields()[0].ty == self.location_type {
+                    expr
+                } else {
+                    Expr::from(ExprKind::MethodCall(
+                        Ident::from(if mutability == Mutability::Immutable { "tracking_ref" } else { "tracking_mut" }),
+                        vec![],
+                        vec![expr]
+                    ))
+                }
+            ),
+            VariantData::Unit => panic!("Empty unit is not trackable")
+        };
+
+        Arm {
+            attrs: vec![],
+            pats: vec![pat],
+            guard: None,
+            body: Box::new(expr)
+        }
+    }
+
+    fn expand_tracking(&self, ast: &MacroInput, mutability: Mutability) -> Tokens {
+        // Helper is provided for handling complex generic types correctly and effortlessly
+        let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+        let (impl_name, method) = if mutability == Mutability::Immutable {
+            (Ident::from("TrackingRef"), quote! {
+                tracking_ref(&self) -> &Option<Span>
+            })
+        } else {
+            (Ident::from("TrackingMut"), quote! {
+                tracking_mut(&mut self) -> &mut Option<Span>
+            })
+        };
+
+        // Used in the quasi-quotation below as `#name`
+        let name = &ast.ident;
+
+        let body = Expr::from(ExprKind::Match(
+            Box::new(self.deref_self_expr.clone()),
+            match ast.body {
+                Body::Struct(ref data) => {
+                    vec![self.expand_tracking_data(Path::from(name.clone()), data, mutability)]
+                },
+                Body::Enum(ref variants) => {
+                    variants.iter().map(|var| {
+                        let path = Path {
+                            global: false,
+                            segments: vec![
+                                PathSegment::from(name.clone()),
+                                PathSegment::from(var.ident.clone())
+                            ]
+                        };
+                        self.expand_tracking_data(path, &var.data, mutability)
+                    }).collect()
+                }
+            }
+        ));
+
+        quote! {
+            // The generated impl
+            impl #impl_generics #impl_name for #name #ty_generics #where_clause {
+                fn #method {
+                    #body
+                }
+            }
+        }
+    }
+
+    fn expand_untrack_data(&self, path: Path, data: &VariantData) -> Arm {
+        let (pat, idents) = match *data {
+            VariantData::Struct(ref fields) => {
+                let mut field_pats = Vec::with_capacity(fields.len());
+                let mut idents = Vec::with_capacity(fields.len());
+
+                for field in fields {
+                    let ident = field.ident.as_ref().unwrap();
+
+                    field_pats.push(FieldPat {
+                        ident: ident.clone(),
+                        pat: Box::new(Pat::Ident(BindingMode::ByRef(Mutability::Mutable), ident.clone(), None)),
+                        is_shorthand: true
+                    });
+
+                    idents.push(ident.clone());
+                }
+
+                (Pat::Struct(path, field_pats, false), idents)
+            },
+            VariantData::Tuple(ref fields) => {
+                let mut pats = Vec::with_capacity(fields.len());
+                let mut idents = Vec::with_capacity(fields.len());
+
+                for i in 0..fields.len() {
+                    let ident = Ident::from(format!("_f{}", i));
+
+                    pats.push(Pat::Ident(BindingMode::ByRef(Mutability::Mutable), ident.clone(), None));
+
+                    idents.push(ident);
+                }
+
+                (Pat::TupleStruct(path, pats, None), idents)
+            },
+            VariantData::Unit => {
+                (Pat::Path(None, path), vec![])
+            }
+        };
+
+        let expr = Expr::from(ExprKind::Block(BlockCheckMode::Default, Block {
+            stmts: idents.into_iter().map(|ident| {
+                Stmt::Semi(Box::new(Expr::from(ExprKind::MethodCall(
+                    Ident::from("untrack"),
+                    vec![],
+                    vec![Expr::from(ExprKind::Path(None, Path::from(ident)))]
+                ))))
+            }).collect()
+        }));
+
+        Arm {
+            attrs: vec![],
+            pats: vec![pat],
+            guard: None,
+            body: Box::new(expr)
+        }
+    }
+
+    pub fn expand_tracking_ref(&self, ast: &MacroInput) -> Tokens {
+        self.expand_tracking(ast, Mutability::Immutable)
+    }
+
+    pub fn expand_tracking_mut(&self, ast: &MacroInput) -> Tokens {
+        self.expand_tracking(ast, Mutability::Mutable)
+    }
+
+    pub fn expand_untrack(&self, ast: &MacroInput) -> Tokens {
+        let mut generics = ast.generics.clone();
+
+        let bound = TyParamBound::Trait(PolyTraitRef {
+            bound_lifetimes: vec![],
+            trait_ref: Path::from("Untrack")
+        }, TraitBoundModifier::None);
+
+        for ty in &mut generics.ty_params {
+            ty.bounds.push(bound.clone());
+        }
+
+        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+        let name = &ast.ident;
+
+        let body = Expr::from(ExprKind::Match(
+            Box::new(self.deref_self_expr.clone()),
+            match ast.body {
+                Body::Struct(ref data) => {
+                    vec![self.expand_untrack_data(Path::from(name.clone()), data)]
+                },
+                Body::Enum(ref variants) => {
+                    variants.iter().map(|var| {
+                        let path = Path {
+                            global: false,
+                            segments: vec![
+                                PathSegment::from(name.clone()),
+                                PathSegment::from(var.ident.clone())
+                            ]
+                        };
+                        self.expand_untrack_data(path, &var.data)
+                    }).collect()
+                }
+            }
+        ));
+
+        quote! {
+            // The generated impl
+            impl #impl_generics Untrack for #name #ty_generics #where_clause {
+                fn untrack(&mut self) {
+                    #body
+                }
+            }
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! register_tracking_derives {
+    () => {
+        register_tracking_derive!(TrackingRef, expand_tracking_ref);
+        register_tracking_derive!(TrackingMut, expand_tracking_mut);
+        register_tracking_derive!(Untrack, expand_untrack);
+    }
+}

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "derive"
+version = "0.0.1"
+authors = ["Ingvar Stepanyan <me@rreverser.com>"]
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+derive-context = { version = "0.0.1", path = "../derive-context" }

--- a/crates/derive/src/lib.rs
+++ b/crates/derive/src/lib.rs
@@ -1,0 +1,29 @@
+#![feature(proc_macro, proc_macro_lib)]
+
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[macro_use]
+extern crate derive_context;
+use derive_context::{Context, parse_macro_input};
+
+macro_rules! register_tracking_derive {
+    ($for_trait:ident, $method:ident) => {
+        #[proc_macro_derive($for_trait)]
+        pub fn $method(input: TokenStream) -> TokenStream {
+            let source = input.to_string();
+            let context = Context::new();
+
+            // Parse the string representation into a syntax tree
+            let ast = parse_macro_input(&source).unwrap();
+
+            // Build the output, possibly using quasi-quotation
+            let expanded = context.$method(&ast);
+
+            // Parse back to a token stream and return it
+            expanded.parse().unwrap()
+        }
+    }
+}
+
+register_tracking_derives!();

--- a/crates/easter/Cargo.toml
+++ b/crates/easter/Cargo.toml
@@ -14,5 +14,5 @@ joker = { version = "0.0.5", path = "../joker" }
 tristate = "0.1.1"
 
 [build-dependencies]
-syn = { version = "0.10.5", features = ["parsing", "printing", "expand", "pretty"] }
+syn = { version = "0.10.5", features = ["parsing", "printing", "expand"] }
 quote = "0.3.10"

--- a/crates/easter/Cargo.toml
+++ b/crates/easter/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-
 name = "easter"
 version = "0.0.5"
 authors = ["Dave Herman <dherman@mozilla.com>"]
@@ -8,7 +7,12 @@ description = "Type definitions for ECMAScript abstract syntax trees."
 documentation = "https://esprit.surge.sh"
 homepage = "https://esprit.surge.sh"
 repository = "https://github.com/dherman/esprit"
+build = "build.rs"
 
 [dependencies]
 joker = { version = "0.0.5", path = "../joker" }
 tristate = "0.1.1"
+
+[build-dependencies]
+syn = { version = "0.10.5", features = ["parsing", "printing", "expand", "pretty"] }
+quote = "0.3.10"

--- a/crates/easter/Cargo.toml
+++ b/crates/easter/Cargo.toml
@@ -9,10 +9,14 @@ homepage = "https://esprit.surge.sh"
 repository = "https://github.com/dherman/esprit"
 build = "build.rs"
 
+[features]
+default = ["derive-context"]
+nightly = ["derive"]
+
 [dependencies]
 joker = { version = "0.0.5", path = "../joker" }
 tristate = "0.1.1"
+derive = { version = "0.0.1", path = "../derive", optional = true }
 
 [build-dependencies]
-syn = { version = "0.10.5", features = ["parsing", "printing", "expand"] }
-quote = "0.3.10"
+derive-context = { version = "0.0.1", path = "../derive-context", optional = true }

--- a/crates/easter/build.rs
+++ b/crates/easter/build.rs
@@ -1,0 +1,156 @@
+extern crate syn;
+
+#[macro_use]
+extern crate quote;
+
+use std::env;
+use std::path::Path as FilePath;
+
+use syn::*;
+use quote::Tokens;
+
+fn get_location_ident() -> Ident {
+    Ident::from("location")
+}
+
+fn get_location_type() -> Ty {
+    Ty::Path(None, Path {
+        global: false,
+        segments: vec![PathSegment {
+            ident: Ident::from("Option"),
+            parameters: PathParameters::AngleBracketed(AngleBracketedParameterData {
+                lifetimes: vec![],
+                types: vec![Ty::Path(None, Path::from("Span"))],
+                bindings: vec![]
+            })
+        }]
+    })
+}
+
+fn get_self_expr() -> Box<Expr> {
+    Box::new(Expr::from(ExprKind::Path(None, Path::from("self"))))
+}
+
+fn expand_tracking_ref_data(path: Path, data: &VariantData, mutability: Mutability) -> Arm {
+    let location_pat = Pat::Ident(BindingMode::ByRef(mutability), get_location_ident(), None);
+
+    let (pat, field) = match *data {
+        VariantData::Struct(_) => (
+            Pat::Struct(path, vec![FieldPat {
+                ident: get_location_ident(),
+                pat: Box::new(location_pat),
+                is_shorthand: true
+            }], true),
+            data.fields().iter().find(|field| field.ident == Some(get_location_ident())).unwrap()
+        ),
+        VariantData::Tuple(ref fields) => (
+            Pat::TupleStruct(path, {
+                let mut v = vec![location_pat];
+                v.extend(std::iter::repeat(Pat::Wild).take(fields.len() - 1));
+                v
+            }, None),
+            &data.fields()[0]
+        ),
+        VariantData::Unit => panic!("Empty unit is not trackable")
+    };
+
+    let expr = Expr::from(ExprKind::Path(None, Path::from(get_location_ident())));
+
+    Arm {
+        attrs: vec![],
+        pats: vec![pat],
+        guard: None,
+        body: Box::new(if field.ty == get_location_type() {
+            expr
+        } else {
+            Expr::from(ExprKind::MethodCall(
+                Ident::from(if mutability == Mutability::Immutable { "tracking_ref" } else { "tracking_mut" }),
+                vec![],
+                vec![expr]
+            ))
+        })
+    }
+}
+
+fn expand_tracking_ref(ast: &MacroInput, mutability: Mutability) -> Tokens {
+    // Used in the quasi-quotation below as `#name`
+    let name = &ast.ident;
+
+    let body = match ast.body {
+        Body::Struct(ref data) => {
+            vec![expand_tracking_ref_data(Path::from(name.clone()), data, mutability)]
+        },
+        Body::Enum(ref variants) => {
+            variants.iter().map(|var| {
+                let path = Path {
+                    global: false,
+                    segments: vec![
+                        PathSegment::from(name.clone()),
+                        PathSegment::from(var.ident.clone())
+                    ]
+                };
+                expand_tracking_ref_data(path, &var.data, mutability)
+            }).collect()
+        }
+    };
+
+    let body = Expr::from(ExprKind::Match(
+        Box::new(Expr::from(ExprKind::Unary(UnOp::Deref, get_self_expr()))),
+        body
+    ));
+
+    // Helper is provided for handling complex generic types correctly and effortlessly
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+    let (impl_name, method) = if mutability == Mutability::Immutable {
+        (Token::Ident(Ident::from("TrackingRef")), quote! {
+            tracking_ref(&self) -> &Option<Span>
+        })
+    } else {
+        (Token::Ident(Ident::from("TrackingMut")), quote! {
+            tracking_mut(&mut self) -> &mut Option<Span>
+        })
+    };
+
+    quote! {
+        // The generated impl
+        impl #impl_generics #impl_name for #name #ty_generics #where_clause {
+            fn #method {
+                #body
+            }
+        }
+    }
+}
+
+pub fn expand_file<S, D>(src: S, dst: D) -> Result<(), String>
+    where S: AsRef<FilePath>,
+          D: AsRef<FilePath>
+{
+    let mut registry = Registry::new();
+    registry.add_derive("TrackingRef", |input: MacroInput| {
+        let tokens = expand_tracking_ref(&input, Mutability::Immutable);
+        let items = parse_items(&tokens.to_string())?;
+        Ok(Expanded {
+            new_items: items,
+            original: Some(input),
+        })
+    });
+    registry.add_derive("TrackingMut", |input: MacroInput| {
+        let tokens = expand_tracking_ref(&input, Mutability::Mutable);
+        let items = parse_items(&tokens.to_string())?;
+        Ok(Expanded {
+            new_items: items,
+            original: Some(input),
+        })
+    });
+    registry.expand_file(src, dst)
+}
+
+fn main() {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+
+    let src = FilePath::new("src/stmt.rs");
+    let dst = FilePath::new(&out_dir).join("stmt.rs");
+
+    expand_file(&src, &dst).unwrap();
+}

--- a/crates/easter/build.rs
+++ b/crates/easter/build.rs
@@ -1,247 +1,18 @@
-extern crate syn;
+#[cfg(feature = "nightly")]
+fn main() {}
 
+#[cfg(not(feature = "nightly"))]
 #[macro_use]
-extern crate quote;
+extern crate derive_context;
 
-use std::env;
-use std::path::{PathBuf, Path as FilePath};
+#[cfg(not(feature = "nightly"))]
+use derive_context::{Context, Registry, Expanded, parse_items};
 
-use syn::*;
-use quote::Tokens;
-
-struct Context {
-    location_ident: Ident,
-    location_expr: Expr,
-    location_type: Ty,
-    deref_self_expr: Expr,
-}
-
-impl Context {
-    pub fn new() -> Self {
-        Context {
-            location_ident: Ident::from("location"),
-
-            location_expr: Expr::from(ExprKind::Path(None, Path::from("location"))),
-
-            location_type: Ty::Path(None, Path {
-                global: false,
-                segments: vec![PathSegment {
-                    ident: Ident::from("Option"),
-                    parameters: PathParameters::AngleBracketed(AngleBracketedParameterData {
-                        lifetimes: vec![],
-                        types: vec![Ty::Path(None, Path::from("Span"))],
-                        bindings: vec![]
-                    })
-                }]
-            }),
-
-            deref_self_expr: Expr::from(ExprKind::Unary(
-                UnOp::Deref,
-                Box::new(Expr::from(ExprKind::Path(None, Path::from("self"))))
-            ))
-        }
-    }
-
-    fn expand_tracking_ref_data(&self, path: Path, data: &VariantData, mutability: Mutability) -> Arm {
-        let location_pat = Pat::Ident(BindingMode::ByRef(mutability), self.location_ident.clone(), None);
-
-        let expr = self.location_expr.clone();
-
-        let (pat, expr) = match *data {
-            VariantData::Struct(_) => (
-                Pat::Struct(path, vec![FieldPat {
-                    ident: self.location_ident.clone(),
-                    pat: Box::new(location_pat),
-                    is_shorthand: true
-                }], true),
-                if data.fields().iter().any(|field| field.ident.as_ref() == Some(&self.location_ident) && field.ty == self.location_type) {
-                    expr
-                } else {
-                    panic!("Struct does not containt `location: Option<Span>`")
-                }
-            ),
-            VariantData::Tuple(ref fields) => (
-                Pat::TupleStruct(path, {
-                    let mut v = Vec::with_capacity(fields.len());
-                    v.push(location_pat);
-                    v.extend(std::iter::repeat(Pat::Wild).take(fields.len() - 1));
-                    v
-                }, None),
-                if data.fields()[0].ty == self.location_type {
-                    expr
-                } else {
-                    Expr::from(ExprKind::MethodCall(
-                        Ident::from(if mutability == Mutability::Immutable { "tracking_ref" } else { "tracking_mut" }),
-                        vec![],
-                        vec![expr]
-                    ))
-                }
-            ),
-            VariantData::Unit => panic!("Empty unit is not trackable")
-        };
-
-        Arm {
-            attrs: vec![],
-            pats: vec![pat],
-            guard: None,
-            body: Box::new(expr)
-        }
-    }
-
-    pub fn expand_tracking_ref(&self, ast: &MacroInput, mutability: Mutability) -> Tokens {
-        // Helper is provided for handling complex generic types correctly and effortlessly
-        let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
-
-        let (impl_name, method) = if mutability == Mutability::Immutable {
-            (Ident::from("TrackingRef"), quote! {
-                tracking_ref(&self) -> &Option<Span>
-            })
-        } else {
-            (Ident::from("TrackingMut"), quote! {
-                tracking_mut(&mut self) -> &mut Option<Span>
-            })
-        };
-
-        // Used in the quasi-quotation below as `#name`
-        let name = &ast.ident;
-
-        let body = Expr::from(ExprKind::Match(
-            Box::new(self.deref_self_expr.clone()),
-            match ast.body {
-                Body::Struct(ref data) => {
-                    vec![self.expand_tracking_ref_data(Path::from(name.clone()), data, mutability)]
-                },
-                Body::Enum(ref variants) => {
-                    variants.iter().map(|var| {
-                        let path = Path {
-                            global: false,
-                            segments: vec![
-                                PathSegment::from(name.clone()),
-                                PathSegment::from(var.ident.clone())
-                            ]
-                        };
-                        self.expand_tracking_ref_data(path, &var.data, mutability)
-                    }).collect()
-                }
-            }
-        ));
-
-        quote! {
-            // The generated impl
-            impl #impl_generics #impl_name for #name #ty_generics #where_clause {
-                fn #method {
-                    #body
-                }
-            }
-        }
-    }
-
-    fn expand_untrack_data(&self, path: Path, data: &VariantData) -> Arm {
-        let (pat, idents) = match *data {
-            VariantData::Struct(ref fields) => {
-                let mut field_pats = Vec::with_capacity(fields.len());
-                let mut idents = Vec::with_capacity(fields.len());
-
-                for field in fields {
-                    let ident = field.ident.as_ref().unwrap();
-
-                    field_pats.push(FieldPat {
-                        ident: ident.clone(),
-                        pat: Box::new(Pat::Ident(BindingMode::ByRef(Mutability::Mutable), ident.clone(), None)),
-                        is_shorthand: true
-                    });
-
-                    idents.push(ident.clone());
-                }
-
-                (Pat::Struct(path, field_pats, false), idents)
-            },
-            VariantData::Tuple(ref fields) => {
-                let mut pats = Vec::with_capacity(fields.len());
-                let mut idents = Vec::with_capacity(fields.len());
-
-                for i in 0..fields.len() {
-                    let ident = Ident::from(format!("_f{}", i));
-
-                    pats.push(Pat::Ident(BindingMode::ByRef(Mutability::Mutable), ident.clone(), None));
-
-                    idents.push(ident);
-                }
-
-                (Pat::TupleStruct(path, pats, None), idents)
-            },
-            VariantData::Unit => {
-                (Pat::Path(None, path), vec![])
-            }
-        };
-
-        let expr = Expr::from(ExprKind::Block(BlockCheckMode::Default, Block {
-            stmts: idents.into_iter().map(|ident| {
-                Stmt::Semi(Box::new(Expr::from(ExprKind::MethodCall(
-                    Ident::from("untrack"),
-                    vec![],
-                    vec![Expr::from(ExprKind::Path(None, Path::from(ident)))]
-                ))))
-            }).collect()
-        }));
-
-        Arm {
-            attrs: vec![],
-            pats: vec![pat],
-            guard: None,
-            body: Box::new(expr)
-        }
-    }
-
-    pub fn expand_untrack(&self, ast: &MacroInput) -> Tokens {
-        let mut generics = ast.generics.clone();
-
-        let bound = TyParamBound::Trait(PolyTraitRef {
-            bound_lifetimes: vec![],
-            trait_ref: Path::from("Untrack")
-        }, TraitBoundModifier::None);
-
-        for ty in &mut generics.ty_params {
-            ty.bounds.push(bound.clone());
-        }
-
-        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-
-        let name = &ast.ident;
-
-        let body = Expr::from(ExprKind::Match(
-            Box::new(self.deref_self_expr.clone()),
-            match ast.body {
-                Body::Struct(ref data) => {
-                    vec![self.expand_untrack_data(Path::from(name.clone()), data)]
-                },
-                Body::Enum(ref variants) => {
-                    variants.iter().map(|var| {
-                        let path = Path {
-                            global: false,
-                            segments: vec![
-                                PathSegment::from(name.clone()),
-                                PathSegment::from(var.ident.clone())
-                            ]
-                        };
-                        self.expand_untrack_data(path, &var.data)
-                    }).collect()
-                }
-            }
-        ));
-
-        quote! {
-            // The generated impl
-            impl #impl_generics Untrack for #name #ty_generics #where_clause {
-                fn untrack(&mut self) {
-                    #body
-                }
-            }
-        }
-    }
-}
-
+#[cfg(not(feature = "nightly"))]
 fn main() {
+    use std::env;
+    use std::path::{PathBuf, Path as FilePath};
+
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let out_path = FilePath::new(&out_dir);
 
@@ -256,29 +27,19 @@ fn main() {
     let registry = {
         let mut registry = Registry::new();
 
-        registry.add_derive("TrackingRef", |input| {
-            let tokens = context.expand_tracking_ref(&input, Mutability::Immutable);
-            Ok(Expanded {
-                new_items: parse_items(&tokens.to_string())?,
-                original: Some(input),
-            })
-        });
+        macro_rules! register_tracking_derive {
+            ($for_trait:ident, $method:ident) => {
+                registry.add_derive(stringify!($for_trait), |input| {
+                    let tokens = context.$method(&input);
+                    Ok(Expanded {
+                        new_items: parse_items(&tokens.to_string())?,
+                        original: Some(input),
+                    })
+                });
+            }
+        }
 
-        registry.add_derive("TrackingMut", |input| {
-            let tokens = context.expand_tracking_ref(&input, Mutability::Mutable);
-            Ok(Expanded {
-                new_items: parse_items(&tokens.to_string())?,
-                original: Some(input),
-            })
-        });
-
-        registry.add_derive("Untrack", |input| {
-            let tokens = context.expand_untrack(&input);
-            Ok(Expanded {
-                new_items: parse_items(&tokens.to_string())?,
-                original: Some(input),
-            })
-        });
+        register_tracking_derives!();
 
         registry
     };

--- a/crates/easter/build.rs
+++ b/crates/easter/build.rs
@@ -9,141 +9,223 @@ use std::path::{PathBuf, Path as FilePath};
 use syn::*;
 use quote::Tokens;
 
-fn get_location_ident() -> Ident {
-    Ident::from("location")
+struct Context {
+    location_ident: Ident,
+    location_expr: Expr,
+    location_type: Ty,
+    deref_self_expr: Expr,
 }
 
-fn get_location_type() -> Ty {
-    Ty::Path(None, Path {
-        global: false,
-        segments: vec![PathSegment {
-            ident: Ident::from("Option"),
-            parameters: PathParameters::AngleBracketed(AngleBracketedParameterData {
-                lifetimes: vec![],
-                types: vec![Ty::Path(None, Path::from("Span"))],
-                bindings: vec![]
-            })
-        }]
-    })
-}
+impl Context {
+    pub fn new() -> Self {
+        Context {
+            location_ident: Ident::from("location"),
 
-fn get_self_expr() -> Box<Expr> {
-    Box::new(Expr::from(ExprKind::Path(None, Path::from("self"))))
-}
+            location_expr: Expr::from(ExprKind::Path(None, Path::from("location"))),
 
-fn expand_tracking_ref_data(path: Path, data: &VariantData, mutability: Mutability) -> Arm {
-    let location_pat = Pat::Ident(BindingMode::ByRef(mutability), get_location_ident(), None);
+            location_type: Ty::Path(None, Path {
+                global: false,
+                segments: vec![PathSegment {
+                    ident: Ident::from("Option"),
+                    parameters: PathParameters::AngleBracketed(AngleBracketedParameterData {
+                        lifetimes: vec![],
+                        types: vec![Ty::Path(None, Path::from("Span"))],
+                        bindings: vec![]
+                    })
+                }]
+            }),
 
-    let (pat, field) = match *data {
-        VariantData::Struct(_) => (
-            Pat::Struct(path, vec![FieldPat {
-                ident: get_location_ident(),
-                pat: Box::new(location_pat),
-                is_shorthand: true
-            }], true),
-            data.fields().iter().find(|field| field.ident == Some(get_location_ident())).unwrap()
-        ),
-        VariantData::Tuple(ref fields) => (
-            Pat::TupleStruct(path, {
-                let mut v = vec![location_pat];
-                v.extend(std::iter::repeat(Pat::Wild).take(fields.len() - 1));
-                v
-            }, None),
-            &data.fields()[0]
-        ),
-        VariantData::Unit => panic!("Empty unit is not trackable")
-    };
-
-    let expr = Expr::from(ExprKind::Path(None, Path::from(get_location_ident())));
-
-    Arm {
-        attrs: vec![],
-        pats: vec![pat],
-        guard: None,
-        body: Box::new(if field.ty == get_location_type() {
-            expr
-        } else {
-            Expr::from(ExprKind::MethodCall(
-                Ident::from(if mutability == Mutability::Immutable { "tracking_ref" } else { "tracking_mut" }),
-                vec![],
-                vec![expr]
+            deref_self_expr: Expr::from(ExprKind::Unary(
+                UnOp::Deref,
+                Box::new(Expr::from(ExprKind::Path(None, Path::from("self"))))
             ))
-        })
-    }
-}
-
-fn expand_tracking_ref(ast: &MacroInput, mutability: Mutability) -> Tokens {
-    // Used in the quasi-quotation below as `#name`
-    let name = &ast.ident;
-
-    let body = match ast.body {
-        Body::Struct(ref data) => {
-            vec![expand_tracking_ref_data(Path::from(name.clone()), data, mutability)]
-        },
-        Body::Enum(ref variants) => {
-            variants.iter().map(|var| {
-                let path = Path {
-                    global: false,
-                    segments: vec![
-                        PathSegment::from(name.clone()),
-                        PathSegment::from(var.ident.clone())
-                    ]
-                };
-                expand_tracking_ref_data(path, &var.data, mutability)
-            }).collect()
         }
-    };
+    }
 
-    let body = Expr::from(ExprKind::Match(
-        Box::new(Expr::from(ExprKind::Unary(UnOp::Deref, get_self_expr()))),
-        body
-    ));
+    fn expand_tracking_ref_data(&self, path: Path, data: &VariantData, mutability: Mutability) -> Arm {
+        let location_pat = Pat::Ident(BindingMode::ByRef(mutability), self.location_ident.clone(), None);
 
-    // Helper is provided for handling complex generic types correctly and effortlessly
-    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+        let (pat, field) = match *data {
+            VariantData::Struct(_) => (
+                Pat::Struct(path, vec![FieldPat {
+                    ident: self.location_ident.clone(),
+                    pat: Box::new(location_pat),
+                    is_shorthand: true
+                }], true),
+                data.fields().iter().find(|field| field.ident.as_ref() == Some(&self.location_ident)).unwrap()
+            ),
+            VariantData::Tuple(ref fields) => (
+                Pat::TupleStruct(path, {
+                    let mut v = vec![location_pat];
+                    v.extend(std::iter::repeat(Pat::Wild).take(fields.len() - 1));
+                    v
+                }, None),
+                &data.fields()[0]
+            ),
+            VariantData::Unit => panic!("Empty unit is not trackable")
+        };
 
-    let (impl_name, method) = if mutability == Mutability::Immutable {
-        (Token::Ident(Ident::from("TrackingRef")), quote! {
-            tracking_ref(&self) -> &Option<Span>
-        })
-    } else {
-        (Token::Ident(Ident::from("TrackingMut")), quote! {
-            tracking_mut(&mut self) -> &mut Option<Span>
-        })
-    };
+        let expr = self.location_expr.clone();
 
-    quote! {
-        // The generated impl
-        impl #impl_generics #impl_name for #name #ty_generics #where_clause {
-            fn #method {
-                #body
+        Arm {
+            attrs: vec![],
+            pats: vec![pat],
+            guard: None,
+            body: Box::new(if field.ty == self.location_type {
+                expr
+            } else {
+                Expr::from(ExprKind::MethodCall(
+                    Ident::from(if mutability == Mutability::Immutable { "tracking_ref" } else { "tracking_mut" }),
+                    vec![],
+                    vec![expr]
+                ))
+            })
+        }
+    }
+
+    pub fn expand_tracking_ref(&self, ast: &MacroInput, mutability: Mutability) -> Tokens {
+        // Helper is provided for handling complex generic types correctly and effortlessly
+        let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+        let (impl_name, method) = if mutability == Mutability::Immutable {
+            (Token::Ident(Ident::from("TrackingRef")), quote! {
+                tracking_ref(&self) -> &Option<Span>
+            })
+        } else {
+            (Token::Ident(Ident::from("TrackingMut")), quote! {
+                tracking_mut(&mut self) -> &mut Option<Span>
+            })
+        };
+
+        // Used in the quasi-quotation below as `#name`
+        let name = &ast.ident;
+
+        let body = Expr::from(ExprKind::Match(
+            Box::new(self.deref_self_expr.clone()),
+            match ast.body {
+                Body::Struct(ref data) => {
+                    vec![self.expand_tracking_ref_data(Path::from(name.clone()), data, mutability)]
+                },
+                Body::Enum(ref variants) => {
+                    variants.iter().map(|var| {
+                        let path = Path {
+                            global: false,
+                            segments: vec![
+                                PathSegment::from(name.clone()),
+                                PathSegment::from(var.ident.clone())
+                            ]
+                        };
+                        self.expand_tracking_ref_data(path, &var.data, mutability)
+                    }).collect()
+                }
+            }
+        ));
+
+        quote! {
+            // The generated impl
+            impl #impl_generics #impl_name for #name #ty_generics #where_clause {
+                fn #method {
+                    #body
+                }
             }
         }
     }
-}
 
-pub fn expand_file<S, D>(src: S, dst: D) -> Result<(), String>
-    where S: AsRef<FilePath>,
-          D: AsRef<FilePath>
-{
-    let mut registry = Registry::new();
-    registry.add_derive("TrackingRef", |input: MacroInput| {
-        let tokens = expand_tracking_ref(&input, Mutability::Immutable);
-        let items = parse_items(&tokens.to_string())?;
-        Ok(Expanded {
-            new_items: items,
-            original: Some(input),
-        })
-    });
-    registry.add_derive("TrackingMut", |input: MacroInput| {
-        let tokens = expand_tracking_ref(&input, Mutability::Mutable);
-        let items = parse_items(&tokens.to_string())?;
-        Ok(Expanded {
-            new_items: items,
-            original: Some(input),
-        })
-    });
-    registry.expand_file(src, dst)
+    fn expand_untrack_data(&self, path: Path, data: &VariantData) -> Arm {
+        let (pat, idents) = match *data {
+            VariantData::Struct(ref fields) => {
+                let field_pats: Vec<_> = fields.iter().map(|field| {
+                    let ident = field.ident.clone().unwrap();
+
+                    FieldPat {
+                        ident: ident.clone(),
+                        pat: Box::new(Pat::Ident(BindingMode::ByRef(Mutability::Mutable), ident, None)),
+                        is_shorthand: true
+                    }
+                }).collect();
+
+                let idents: Vec<_> = fields.iter().map(|field| field.ident.clone().unwrap()).collect();
+
+                (
+                    Pat::Struct(path, field_pats, false),
+                    idents
+                )
+            },
+            VariantData::Tuple(ref fields) => {
+                let pats: Vec<_> = fields.iter().enumerate().map(|(i, _)| {
+                    Pat::Ident(BindingMode::ByRef(Mutability::Mutable), Ident::from(format!("_f{}", i)), None)
+                }).collect();
+
+                let idents: Vec<_> = fields.iter().enumerate().map(|(i, _)| {
+                    Ident::from(format!("_f{}", i))
+                }).collect();
+
+                (
+                    Pat::TupleStruct(path, pats, None),
+                    idents
+                )
+            },
+            VariantData::Unit => {
+                (
+                    Pat::Path(None, path),
+                    vec![]
+                )
+            }
+        };
+
+        let expr = Expr::from(ExprKind::Block(BlockCheckMode::Default, Block {
+            stmts: idents.into_iter().map(|ident| {
+                Stmt::Semi(Box::new(Expr::from(ExprKind::MethodCall(
+                    Ident::from("untrack"),
+                    vec![],
+                    vec![Expr::from(ExprKind::Path(None, Path::from(ident)))]
+                ))))
+            }).collect()
+        }));
+
+        Arm {
+            attrs: vec![],
+            pats: vec![pat],
+            guard: None,
+            body: Box::new(expr)
+        }
+    }
+
+    pub fn expand_untrack(&self, ast: &MacroInput) -> Tokens {
+        let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+        let name = &ast.ident;
+
+        let body = Expr::from(ExprKind::Match(
+            Box::new(self.deref_self_expr.clone()),
+            match ast.body {
+                Body::Struct(ref data) => {
+                    vec![self.expand_untrack_data(Path::from(name.clone()), data)]
+                },
+                Body::Enum(ref variants) => {
+                    variants.iter().map(|var| {
+                        let path = Path {
+                            global: false,
+                            segments: vec![
+                                PathSegment::from(name.clone()),
+                                PathSegment::from(var.ident.clone())
+                            ]
+                        };
+                        self.expand_untrack_data(path, &var.data)
+                    }).collect()
+                }
+            }
+        ));
+
+        quote! {
+            // The generated impl
+            impl #impl_generics Untrack for #name #ty_generics #where_clause {
+                fn untrack(&mut self) {
+                    #body
+                }
+            }
+        }
+    }
 }
 
 fn main() {
@@ -156,12 +238,44 @@ fn main() {
         buf
     };
 
+    let context = Context::new();
+
+    let registry = {
+        let mut registry = Registry::new();
+
+        registry.add_derive("TrackingRef", |input: MacroInput| {
+            let tokens = context.expand_tracking_ref(&input, Mutability::Immutable);
+            Ok(Expanded {
+                new_items: parse_items(&tokens.to_string())?,
+                original: Some(input),
+            })
+        });
+
+        registry.add_derive("TrackingMut", |input: MacroInput| {
+            let tokens = context.expand_tracking_ref(&input, Mutability::Mutable);
+            Ok(Expanded {
+                new_items: parse_items(&tokens.to_string())?,
+                original: Some(input),
+            })
+        });
+
+        registry.add_derive("Untrack", |input: MacroInput| {
+            let tokens = context.expand_untrack(&input);
+            Ok(Expanded {
+                new_items: parse_items(&tokens.to_string())?,
+                original: Some(input),
+            })
+        });
+
+        registry
+    };
+
     for entry in src_path.read_dir().unwrap() {
         let path = entry.unwrap().path();
         let file_name = path.file_name().unwrap();
         if file_name != "lib.rs" {
             let dest = out_path.join(file_name);
-            expand_file(&path, &dest).unwrap();
+            registry.expand_file(&path, &dest).unwrap();
         }
     }
 }

--- a/crates/easter/build.rs
+++ b/crates/easter/build.rs
@@ -192,7 +192,18 @@ impl Context {
     }
 
     pub fn expand_untrack(&self, ast: &MacroInput) -> Tokens {
-        let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+        let mut generics = ast.generics.clone();
+
+        let bound = TyParamBound::Trait(PolyTraitRef {
+            bound_lifetimes: vec![],
+            trait_ref: Path::from("Untrack")
+        }, TraitBoundModifier::None);
+
+        for ty in &mut generics.ty_params {
+            ty.bounds.push(bound.clone());
+        }
+
+        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
         let name = &ast.ident;
 

--- a/crates/easter/src/decl.rs
+++ b/crates/easter/src/decl.rs
@@ -7,75 +7,28 @@ use patt::{Patt, CompoundPatt};
 use expr::Expr;
 use punc::Semi;
 
-#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut, Untrack)]
 pub enum Import {
     // ES6: more import forms
     ForEffect(Option<Span>, StringLiteral)
 }
 
-impl Untrack for Import {
-    fn untrack(&mut self) {
-        match *self {
-            Import::ForEffect(ref mut location, _) => { *location = None; }
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut, Untrack)]
 pub enum Export {
     // ES6: more export forms
     Var(Option<Span>, Vec<Dtor>, Semi),
     Decl(Decl)
 }
 
-impl Untrack for Export {
-    fn untrack(&mut self) {
-        match *self {
-            Export::Var(ref mut location, ref mut dtors, ref mut semi) => {
-                *location = None;
-                dtors.untrack();
-                semi.untrack();
-            }
-            Export::Decl(ref mut decl) => {
-                decl.untrack();
-            }
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut, Untrack)]
 pub enum Decl {
     Fun(Fun)
 }
 
-impl Untrack for Decl {
-    fn untrack(&mut self) {
-        let Decl::Fun(ref mut fun) = *self;
-        fun.untrack();
-    }
-}
-
-#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut, Untrack)]
 pub enum Dtor {
     Simple(Option<Span>, Id, Option<Expr>),
     Compound(Option<Span>, CompoundPatt<Id>, Expr)
-}
-
-impl Untrack for Dtor {
-    fn untrack(&mut self) {
-        match *self {
-            Dtor::Simple(ref mut location, ref mut id, ref mut init) => {
-                *location = None;
-                id.untrack();
-                init.untrack();
-            }
-            Dtor::Compound(ref mut location, ref mut patt, ref mut init) => {
-                *location = None;
-                patt.untrack();
-                init.untrack();
-            }
-        }
-    }
 }
 
 pub trait DtorExt {

--- a/crates/easter/src/decl.rs
+++ b/crates/easter/src/decl.rs
@@ -7,26 +7,10 @@ use patt::{Patt, CompoundPatt};
 use expr::Expr;
 use punc::Semi;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub enum Import {
     // ES6: more import forms
     ForEffect(Option<Span>, StringLiteral)
-}
-
-impl TrackingRef for Import {
-    fn tracking_ref(&self) -> &Option<Span> {
-        match *self {
-            Import::ForEffect(ref location, _) => location
-        }
-    }
-}
-
-impl TrackingMut for Import {
-    fn tracking_mut(&mut self) -> &mut Option<Span> {
-        match *self {
-            Import::ForEffect(ref mut location, _) => location
-        }
-    }
 }
 
 impl Untrack for Import {
@@ -37,29 +21,11 @@ impl Untrack for Import {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub enum Export {
     // ES6: more export forms
     Var(Option<Span>, Vec<Dtor>, Semi),
     Decl(Decl)
-}
-
-impl TrackingRef for Export {
-    fn tracking_ref(&self) -> &Option<Span> {
-        match *self {
-            Export::Var(ref location, _, _) => location,
-            Export::Decl(ref decl) => decl.tracking_ref()
-        }
-    }
-}
-
-impl TrackingMut for Export {
-    fn tracking_mut(&mut self) -> &mut Option<Span> {
-        match *self {
-            Export::Var(ref mut location, _, _) => location,
-            Export::Decl(ref mut decl) => decl.tracking_mut()
-        }
-    }
 }
 
 impl Untrack for Export {
@@ -77,23 +43,9 @@ impl Untrack for Export {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub enum Decl {
     Fun(Fun)
-}
-
-impl TrackingRef for Decl {
-    fn tracking_ref(&self) -> &Option<Span> {
-        let Decl::Fun(ref fun) = *self;
-        fun.tracking_ref()
-    }
-}
-
-impl TrackingMut for Decl {
-    fn tracking_mut(&mut self) -> &mut Option<Span> {
-        let Decl::Fun(ref mut fun) = *self;
-        fun.tracking_mut()
-    }
 }
 
 impl Untrack for Decl {
@@ -103,28 +55,10 @@ impl Untrack for Decl {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub enum Dtor {
     Simple(Option<Span>, Id, Option<Expr>),
     Compound(Option<Span>, CompoundPatt<Id>, Expr)
-}
-
-impl TrackingRef for Dtor {
-    fn tracking_ref(&self) -> &Option<Span> {
-        match *self {
-            Dtor::Simple(ref location, _, _)
-          | Dtor::Compound(ref location, _, _) => location
-        }
-    }
-}
-
-impl TrackingMut for Dtor {
-    fn tracking_mut(&mut self) -> &mut Option<Span> {
-        match *self {
-            Dtor::Simple(ref mut location, _, _)
-          | Dtor::Compound(ref mut location, _, _) => location
-        }
-    }
 }
 
 impl Untrack for Dtor {

--- a/crates/easter/src/expr.rs
+++ b/crates/easter/src/expr.rs
@@ -9,7 +9,7 @@ use punc::{Unop, Binop, Assop, Logop};
 use id::Id;
 use patt::{Patt, AssignTarget};
 
-#[derive(Clone, TrackingRef, TrackingMut)]
+#[derive(Clone, TrackingRef, TrackingMut, Untrack)]
 pub enum Expr {
     This(Option<Span>),
     Id(Id),
@@ -124,41 +124,6 @@ impl Debug for Expr {
             &Expr::Number(_, ref lit)                        => fmt.debug_tuple("Number").field(lit).finish(),
             &Expr::RegExp(_, ref lit)                        => fmt.debug_tuple("RegExp").field(lit).finish(),
             &Expr::String(_, ref lit)                        => fmt.debug_tuple("String").field(lit).finish()
-        }
-    }
-}
-
-impl Untrack for Expr {
-    fn untrack(&mut self) {
-        *self.tracking_mut() = None;
-        match *self {
-            Expr::This(_)                                              => { }
-            Expr::Id(ref mut id)                                       => { id.untrack(); }
-            Expr::Arr(_, ref mut exprs)                                => { exprs.untrack(); }
-            Expr::Obj(_, ref mut props)                                => { props.untrack(); }
-            Expr::Fun(ref mut fun)                                     => { fun.untrack(); }
-            Expr::Seq(_, ref mut exprs)                                => { exprs.untrack(); }
-            Expr::Unop(_, ref mut op, ref mut expr)                    => { op.untrack(); expr.untrack(); }
-            Expr::Binop(_, ref mut op, ref mut left, ref mut right)    => { op.untrack(); left.untrack(); right.untrack(); }
-            Expr::Logop(_, ref mut op, ref mut left, ref mut right)    => { op.untrack(); left.untrack(); right.untrack(); }
-            Expr::PreInc(_, ref mut expr)                              => { expr.untrack(); }
-            Expr::PostInc(_, ref mut expr)                             => { expr.untrack(); }
-            Expr::PreDec(_, ref mut expr)                              => { expr.untrack(); }
-            Expr::PostDec(_, ref mut expr)                             => { expr.untrack(); }
-            Expr::Assign(_, ref mut patt, ref mut expr)                => { patt.untrack(); expr.untrack(); }
-            Expr::BinAssign(_, ref mut op, ref mut patt, ref mut expr) => { op.untrack(); patt.untrack(); expr.untrack(); }
-            Expr::Cond(_, ref mut test, ref mut cons, ref mut alt)     => { test.untrack(); cons.untrack(); alt.untrack(); }
-            Expr::Call(_, ref mut callee, ref mut args)                => { callee.untrack(); args.untrack(); }
-            Expr::New(_, ref mut ctor, ref mut args)                   => { ctor.untrack(); args.untrack(); }
-            Expr::Dot(_, ref mut obj, ref mut key)                     => { obj.untrack(); key.untrack(); }
-            Expr::Brack(_, ref mut obj, ref mut prop)                  => { obj.untrack(); prop.untrack(); }
-            Expr::NewTarget(_)                                         => { }
-            Expr::True(_)                                              => { }
-            Expr::False(_)                                             => { }
-            Expr::Null(_)                                              => { }
-            Expr::Number(_, _)                                         => { }
-            Expr::RegExp(_, _)                                         => { }
-            Expr::String(_, _)                                         => { }
         }
     }
 }

--- a/crates/easter/src/expr.rs
+++ b/crates/easter/src/expr.rs
@@ -9,7 +9,7 @@ use punc::{Unop, Binop, Assop, Logop};
 use id::Id;
 use patt::{Patt, AssignTarget};
 
-#[derive(Clone)]
+#[derive(Clone, TrackingRef, TrackingMut)]
 pub enum Expr {
     This(Option<Span>),
     Id(Id),
@@ -38,74 +38,6 @@ pub enum Expr {
     Number(Option<Span>, NumberLiteral),
     RegExp(Option<Span>, RegExpLiteral),
     String(Option<Span>, StringLiteral)
-}
-
-impl TrackingRef for Expr {
-    fn tracking_ref(&self) -> &Option<Span> {
-        match *self {
-            Expr::This(ref location)
-          | Expr::Arr(ref location, _)
-          | Expr::Obj(ref location, _)
-          | Expr::Seq(ref location, _)
-          | Expr::Unop(ref location, _, _)
-          | Expr::Binop(ref location, _, _, _)
-          | Expr::Logop(ref location, _, _, _)
-          | Expr::PreInc(ref location, _)
-          | Expr::PostInc(ref location, _)
-          | Expr::PreDec(ref location, _)
-          | Expr::PostDec(ref location, _)
-          | Expr::Assign(ref location, _, _)
-          | Expr::BinAssign(ref location, _, _, _)
-          | Expr::Cond(ref location, _, _, _)
-          | Expr::Call(ref location, _, _)
-          | Expr::New(ref location, _, _)
-          | Expr::Dot(ref location, _, _)
-          | Expr::Brack(ref location, _, _)
-          | Expr::NewTarget(ref location)
-          | Expr::True(ref location)
-          | Expr::False(ref location)
-          | Expr::Null(ref location)
-          | Expr::Number(ref location, _)
-          | Expr::RegExp(ref location, _)
-          | Expr::String(ref location, _) => location,
-            Expr::Id(ref id) => id.tracking_ref(),
-            Expr::Fun(ref fun) => fun.tracking_ref()
-        }
-    }
-}
-
-impl TrackingMut for Expr {
-    fn tracking_mut(&mut self) -> &mut Option<Span> {
-        match *self {
-            Expr::This(ref mut location)
-          | Expr::Arr(ref mut location, _)
-          | Expr::Obj(ref mut location, _)
-          | Expr::Seq(ref mut location, _)
-          | Expr::Unop(ref mut location, _, _)
-          | Expr::Binop(ref mut location, _, _, _)
-          | Expr::Logop(ref mut location, _, _, _)
-          | Expr::PreInc(ref mut location, _)
-          | Expr::PostInc(ref mut location, _)
-          | Expr::PreDec(ref mut location, _)
-          | Expr::PostDec(ref mut location, _)
-          | Expr::Assign(ref mut location, _, _)
-          | Expr::BinAssign(ref mut location, _, _, _)
-          | Expr::Cond(ref mut location, _, _, _)
-          | Expr::Call(ref mut location, _, _)
-          | Expr::New(ref mut location, _, _)
-          | Expr::Dot(ref mut location, _, _)
-          | Expr::Brack(ref mut location, _, _)
-          | Expr::NewTarget(ref mut location)
-          | Expr::True(ref mut location)
-          | Expr::False(ref mut location)
-          | Expr::Null(ref mut location)
-          | Expr::Number(ref mut location, _)
-          | Expr::RegExp(ref mut location, _)
-          | Expr::String(ref mut location, _) => location,
-            Expr::Id(ref mut id) => id.tracking_mut(),
-            Expr::Fun(ref mut fun) => fun.tracking_mut()
-        }
-    }
 }
 
 impl PartialEq for Expr {

--- a/crates/easter/src/fun.rs
+++ b/crates/easter/src/fun.rs
@@ -4,18 +4,10 @@ use id::Id;
 use patt::Patt;
 use stmt::Script;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub struct Params {
     pub location: Option<Span>,
     pub list: Vec<Patt<Id>>
-}
-
-impl TrackingRef for Params {
-    fn tracking_ref(&self) -> &Option<Span> { &self.location }
-}
-
-impl TrackingMut for Params {
-    fn tracking_mut(&mut self) -> &mut Option<Span> { &mut self.location }
 }
 
 impl Untrack for Params {
@@ -25,20 +17,12 @@ impl Untrack for Params {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub struct Fun {
     pub location: Option<Span>,
     pub id: Option<Id>,
     pub params: Params,
     pub body: Script
-}
-
-impl TrackingRef for Fun {
-    fn tracking_ref(&self) -> &Option<Span> { &self.location }
-}
-
-impl TrackingMut for Fun {
-    fn tracking_mut(&mut self) -> &mut Option<Span> { &mut self.location }
 }
 
 impl Untrack for Fun {

--- a/crates/easter/src/fun.rs
+++ b/crates/easter/src/fun.rs
@@ -4,32 +4,16 @@ use id::Id;
 use patt::Patt;
 use stmt::Script;
 
-#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut, Untrack)]
 pub struct Params {
     pub location: Option<Span>,
     pub list: Vec<Patt<Id>>
 }
 
-impl Untrack for Params {
-    fn untrack(&mut self) {
-        self.location = None;
-        self.list.untrack();
-    }
-}
-
-#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut, Untrack)]
 pub struct Fun {
     pub location: Option<Span>,
     pub id: Option<Id>,
     pub params: Params,
     pub body: Script
-}
-
-impl Untrack for Fun {
-    fn untrack(&mut self) {
-        self.location = None;
-        self.id.untrack();
-        self.params.untrack();
-        self.body.untrack();
-    }
 }

--- a/crates/easter/src/id.rs
+++ b/crates/easter/src/id.rs
@@ -6,7 +6,7 @@ use expr::Expr;
 use decl::Dtor;
 use patt::Patt;
 
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub struct Id {
     pub location: Option<Span>,
     pub name: Name
@@ -24,14 +24,6 @@ impl DerefMut for Id {
     fn deref_mut(&mut self) -> &mut Option<Span> {
         &mut self.location
     }
-}
-
-impl TrackingRef for Id {
-    fn tracking_ref(&self) -> &Option<Span> { &self.location }
-}
-
-impl TrackingMut for Id {
-    fn tracking_mut(&mut self) -> &mut Option<Span> { &mut self.location }
 }
 
 impl Untrack for Id {

--- a/crates/easter/src/id.rs
+++ b/crates/easter/src/id.rs
@@ -1,4 +1,3 @@
-use std::ops::{Deref, DerefMut};
 use joker::word::Name;
 use joker::track::{TrackingRef, TrackingMut, Untrack, Span};
 
@@ -10,20 +9,6 @@ use patt::Patt;
 pub struct Id {
     pub location: Option<Span>,
     pub name: Name
-}
-
-impl Deref for Id {
-    type Target = Option<Span>;
-
-    fn deref(&self) -> &Option<Span> {
-        &self.location
-    }
-}
-
-impl DerefMut for Id {
-    fn deref_mut(&mut self) -> &mut Option<Span> {
-        &mut self.location
-    }
 }
 
 impl Untrack for Id {

--- a/crates/easter/src/lib.rs
+++ b/crates/easter/src/lib.rs
@@ -1,6 +1,18 @@
+#![cfg_attr(feature = "nightly", feature(proc_macro))]
+
 extern crate joker;
 extern crate tristate;
 
+#[cfg(feature = "nightly")]
+#[macro_use]
+extern crate derive;
+
+#[cfg(feature = "nightly")]
+macro_rules! pub_mod {
+    ($name:ident) => (pub mod $name;)
+}
+
+#[cfg(not(feature = "nightly"))]
 macro_rules! pub_mod {
     ($name:ident) => (pub mod $name {
         include!(concat!(env!("OUT_DIR"), "/", stringify!($name), ".rs"));

--- a/crates/easter/src/lib.rs
+++ b/crates/easter/src/lib.rs
@@ -1,14 +1,18 @@
 extern crate joker;
 extern crate tristate;
 
-pub mod id;
-pub mod fun;
-pub mod obj;
-pub mod stmt {
-    include!(concat!(env!("OUT_DIR"), "/stmt.rs"));
+macro_rules! pub_mod {
+    ($name:ident) => (pub mod $name {
+        include!(concat!(env!("OUT_DIR"), "/", stringify!($name), ".rs"));
+    })
 }
-pub mod expr;
-pub mod decl;
-pub mod patt;
-pub mod punc;
-pub mod cover;
+
+pub_mod!(id);
+pub_mod!(fun);
+pub_mod!(obj);
+pub_mod!(stmt);
+pub_mod!(expr);
+pub_mod!(decl);
+pub_mod!(patt);
+pub_mod!(punc);
+pub_mod!(cover);

--- a/crates/easter/src/lib.rs
+++ b/crates/easter/src/lib.rs
@@ -4,7 +4,9 @@ extern crate tristate;
 pub mod id;
 pub mod fun;
 pub mod obj;
-pub mod stmt;
+pub mod stmt {
+    include!(concat!(env!("OUT_DIR"), "/stmt.rs"));
+}
 pub mod expr;
 pub mod decl;
 pub mod patt;

--- a/crates/easter/src/obj.rs
+++ b/crates/easter/src/obj.rs
@@ -16,19 +16,11 @@ impl Untrack for DotKey {
     fn untrack(&mut self) { self.location = None; }
 }
 
-#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut, Untrack)]
 pub struct Prop {
     pub location: Option<Span>,
     pub key: PropKey,
     pub val: PropVal
-}
-
-impl Untrack for Prop {
-    fn untrack(&mut self) {
-        self.location = None;
-        self.key.untrack();
-        self.val.untrack();
-    }
 }
 
 #[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
@@ -44,26 +36,9 @@ impl Untrack for PropKey {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut, Untrack)]
 pub enum PropVal {
     Init(Expr),
     Get(Option<Span>, Script),
     Set(Option<Span>, Patt<Id>, Script)
-}
-
-impl Untrack for PropVal {
-    fn untrack(&mut self) {
-        match *self {
-            PropVal::Init(ref mut expr) => { expr.untrack(); }
-            PropVal::Get(ref mut location, ref mut stmts) => {
-                *location = None;
-                stmts.untrack();
-            }
-            PropVal::Set(ref mut location, ref mut patt, ref mut stmts) => {
-                *location = None;
-                patt.untrack();
-                stmts.untrack();
-            }
-        }
-    }
 }

--- a/crates/easter/src/obj.rs
+++ b/crates/easter/src/obj.rs
@@ -6,37 +6,21 @@ use expr::Expr;
 use stmt::Script;
 use patt::Patt;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub struct DotKey {
     pub location: Option<Span>,
     pub value: String
-}
-
-impl TrackingRef for DotKey {
-    fn tracking_ref(&self) -> &Option<Span> { &self.location }
-}
-
-impl TrackingMut for DotKey {
-    fn tracking_mut(&mut self) -> &mut Option<Span> { &mut self.location }
 }
 
 impl Untrack for DotKey {
     fn untrack(&mut self) { self.location = None; }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub struct Prop {
     pub location: Option<Span>,
     pub key: PropKey,
     pub val: PropVal
-}
-
-impl TrackingRef for Prop {
-    fn tracking_ref(&self) -> &Option<Span> { &self.location }
-}
-
-impl TrackingMut for Prop {
-    fn tracking_mut(&mut self) -> &mut Option<Span> { &mut self.location }
 }
 
 impl Untrack for Prop {
@@ -47,31 +31,11 @@ impl Untrack for Prop {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub enum PropKey {
     Id(Option<Span>, String),
     String(Option<Span>, StringLiteral),
     Number(Option<Span>, NumberLiteral)
-}
-
-impl TrackingRef for PropKey {
-    fn tracking_ref(&self) -> &Option<Span> {
-        match *self {
-            PropKey::Id(ref location, _)
-          | PropKey::String(ref location, _)
-          | PropKey::Number(ref location, _) => location
-        }
-    }
-}
-
-impl TrackingMut for PropKey {
-    fn tracking_mut(&mut self) -> &mut Option<Span> {
-        match *self {
-            PropKey::Id(ref mut location, _)
-          | PropKey::String(ref mut location, _)
-          | PropKey::Number(ref mut location, _) => location
-        }
-    }
 }
 
 impl Untrack for PropKey {
@@ -80,31 +44,11 @@ impl Untrack for PropKey {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub enum PropVal {
     Init(Expr),
     Get(Option<Span>, Script),
     Set(Option<Span>, Patt<Id>, Script)
-}
-
-impl TrackingRef for PropVal {
-    fn tracking_ref(&self) -> &Option<Span> {
-        match *self {
-            PropVal::Init(ref expr) => expr.tracking_ref(),
-            PropVal::Get(ref location, _)
-          | PropVal::Set(ref location, _, _) => location
-        }
-    }
-}
-
-impl TrackingMut for PropVal {
-    fn tracking_mut(&mut self) -> &mut Option<Span> {
-        match *self {
-            PropVal::Init(ref mut expr) => expr.tracking_mut(),
-            PropVal::Get(ref mut location, _)
-          | PropVal::Set(ref mut location, _, _) => location
-        }
-    }
 }
 
 impl Untrack for PropVal {

--- a/crates/easter/src/patt.rs
+++ b/crates/easter/src/patt.rs
@@ -4,43 +4,20 @@ use id::Id;
 use expr::Expr;
 use obj::{PropKey, DotKey};
 
-#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut, Untrack)]
 pub enum CompoundPatt<T> {
     Arr(Option<Span>, Vec<Option<Patt<T>>>),
     Obj(Option<Span>, Vec<PropPatt<T>>)
 }
 
-impl<T: Untrack> Untrack for CompoundPatt<T> {
-    fn untrack(&mut self) {
-        match *self {
-            CompoundPatt::Arr(ref mut location, ref mut patts) => {
-                *location = None;
-                patts.untrack();
-            }
-            CompoundPatt::Obj(ref mut location, ref mut props) => {
-                *location = None;
-                props.untrack();
-            }
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut, Untrack)]
 pub struct PropPatt<T> {
     pub location: Option<Span>,
     pub key: PropKey,
     pub patt: Patt<T>
 }
 
-impl<T: Untrack> Untrack for PropPatt<T> {
-    fn untrack(&mut self) {
-        self.location = None;
-        self.key.untrack();
-        self.patt.untrack();
-    }
-}
-
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Untrack)]
 pub enum Patt<T> {
     Simple(T),
     Compound(CompoundPatt<T>)
@@ -69,15 +46,6 @@ impl<T: TrackingMut> TrackingMut for Patt<T> {
         match *self {
             Patt::Simple(ref mut simple) => simple.tracking_mut(),
             Patt::Compound(ref mut patt) => patt.tracking_mut()
-        }
-    }
-}
-
-impl<T: Untrack> Untrack for Patt<T> {
-    fn untrack(&mut self) {
-        match *self {
-            Patt::Simple(ref mut simple) => { simple.untrack(); }
-            Patt::Compound(ref mut patt) => { patt.untrack(); }
         }
     }
 }

--- a/crates/easter/src/patt.rs
+++ b/crates/easter/src/patt.rs
@@ -4,28 +4,10 @@ use id::Id;
 use expr::Expr;
 use obj::{PropKey, DotKey};
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub enum CompoundPatt<T> {
     Arr(Option<Span>, Vec<Option<Patt<T>>>),
     Obj(Option<Span>, Vec<PropPatt<T>>)
-}
-
-impl<T> TrackingRef for CompoundPatt<T> {
-    fn tracking_ref(&self) -> &Option<Span> {
-        match *self {
-            CompoundPatt::Arr(ref location, _)
-          | CompoundPatt::Obj(ref location, _) => location
-        }
-    }
-}
-
-impl<T> TrackingMut for CompoundPatt<T> {
-    fn tracking_mut(&mut self) -> &mut Option<Span> {
-        match *self {
-            CompoundPatt::Arr(ref mut location, _)
-          | CompoundPatt::Obj(ref mut location, _) => { location }
-        }
-    }
 }
 
 impl<T: Untrack> Untrack for CompoundPatt<T> {
@@ -43,19 +25,11 @@ impl<T: Untrack> Untrack for CompoundPatt<T> {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub struct PropPatt<T> {
     pub location: Option<Span>,
     pub key: PropKey,
     pub patt: Patt<T>
-}
-
-impl<T> TrackingRef for PropPatt<T> {
-    fn tracking_ref(&self) -> &Option<Span> { &self.location }
-}
-
-impl<T> TrackingMut for PropPatt<T> {
-    fn tracking_mut(&mut self) -> &mut Option<Span> { &mut self.location }
 }
 
 impl<T: Untrack> Untrack for PropPatt<T> {
@@ -108,31 +82,11 @@ impl<T: Untrack> Untrack for Patt<T> {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub enum AssignTarget {
     Id(Id),
     Dot(Option<Span>, Box<Expr>, DotKey),
     Brack(Option<Span>, Box<Expr>, Box<Expr>)
-}
-
-impl TrackingRef for AssignTarget {
-    fn tracking_ref(&self) -> &Option<Span> {
-        match *self {
-            AssignTarget::Id(ref id) => id.tracking_ref(),
-            AssignTarget::Dot(ref location, _, _)
-          | AssignTarget::Brack(ref location, _, _) => location
-        }
-    }
-}
-
-impl TrackingMut for AssignTarget {
-    fn tracking_mut(&mut self) -> &mut Option<Span> {
-        match *self {
-            AssignTarget::Id(ref mut id) => id.tracking_mut(),
-            AssignTarget::Dot(ref mut location, _, _)
-          | AssignTarget::Brack(ref mut location, _, _) => location
-        }
-    }
 }
 
 impl Untrack for AssignTarget {

--- a/crates/easter/src/patt.rs
+++ b/crates/easter/src/patt.rs
@@ -82,29 +82,10 @@ impl<T: Untrack> Untrack for Patt<T> {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut, Untrack)]
 pub enum AssignTarget {
     Id(Id),
     Dot(Option<Span>, Box<Expr>, DotKey),
     Brack(Option<Span>, Box<Expr>, Box<Expr>)
 }
 
-impl Untrack for AssignTarget {
-    fn untrack(&mut self) {
-        match *self {
-            AssignTarget::Id(ref mut id) => {
-                id.untrack();
-            }
-            AssignTarget::Dot(ref mut location, ref mut obj, ref mut prop) => {
-                *location = None;
-                obj.untrack();
-                prop.untrack();
-            }
-            AssignTarget::Brack(ref mut location, ref mut obj, ref mut prop) => {
-                *location = None;
-                obj.untrack();
-                prop.untrack();
-            }
-        }
-    }
-}

--- a/crates/easter/src/punc.rs
+++ b/crates/easter/src/punc.rs
@@ -45,7 +45,7 @@ impl FromStr for UnopTag {
     }
 }
 
-#[derive(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone, TrackingRef, TrackingMut)]
 pub struct Op<T> {
     pub location: Option<Span>,
     pub tag: T
@@ -60,14 +60,6 @@ impl<T: FromStr> FromStr for Op<T> {
             Err(_)  => Err(())
         }
     }
-}
-
-impl<T> TrackingRef for Op<T> {
-    fn tracking_ref(&self) -> &Option<Span> { &self.location }
-}
-
-impl<T> TrackingMut for Op<T> {
-    fn tracking_mut(&mut self) -> &mut Option<Span> { &mut self.location }
 }
 
 impl<T: Debug> Debug for Op<T> {

--- a/crates/easter/src/stmt.rs
+++ b/crates/easter/src/stmt.rs
@@ -30,19 +30,11 @@ pub enum Stmt {
     Debugger(Option<Span>, Semi)
 }
 
-#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut, Untrack)]
 pub struct Body<Item> {
     pub location: Option<Span>,
     pub dirs: Vec<Dir>,
     pub items: Vec<Item>
-}
-
-impl<Item: Untrack> Untrack for Body<Item> {
-    fn untrack(&mut self) {
-        self.location = None;
-        self.dirs.untrack();
-        self.items.untrack();
-    }
 }
 
 pub type Script = Body<StmtListItem>;

--- a/crates/easter/src/stmt.rs
+++ b/crates/easter/src/stmt.rs
@@ -7,7 +7,7 @@ use decl::{Decl, Dtor, Import, Export};
 use patt::{Patt, AssignTarget};
 use punc::Semi;
 
-#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut, Untrack)]
 pub enum Stmt {
     Empty(Option<Span>),
     Block(Option<Span>, Vec<StmtListItem>),
@@ -82,57 +82,14 @@ impl Stmt {
     }
 }
 
-impl Untrack for Stmt {
-    fn untrack(&mut self) {
-        *self.tracking_mut() = None;
-        match *self {
-            Stmt::Empty(_)                                                       => { }
-            Stmt::Block(_, ref mut items)                                        => { items.untrack(); }
-            Stmt::Var(_, ref mut dtors, ref mut semi)                            => { dtors.untrack(); semi.untrack(); }
-            Stmt::Expr(_, ref mut expr, ref mut semi)                            => { expr.untrack(); semi.untrack(); }
-            Stmt::If(_, ref mut test, ref mut cons, ref mut alt)                 => { test.untrack(); cons.untrack(); alt.untrack(); }
-            Stmt::Label(_, ref mut lab, ref mut stmt)                            => { lab.untrack(); stmt.untrack(); }
-            Stmt::Break(_, ref mut lab, ref mut semi)                            => { lab.untrack(); semi.untrack(); }
-            Stmt::Cont(_, ref mut lab, ref mut semi)                             => { lab.untrack(); semi.untrack(); }
-            Stmt::With(_, ref mut expr, ref mut stmt)                            => { expr.untrack(); stmt.untrack(); }
-            Stmt::Switch(_, ref mut expr, ref mut cases)                         => { expr.untrack(); cases.untrack(); }
-            Stmt::Return(_, ref mut expr, ref mut semi)                          => { expr.untrack(); semi.untrack(); }
-            Stmt::Throw(_, ref mut expr, ref mut semi)                           => { expr.untrack(); semi.untrack(); }
-            Stmt::Try(_, ref mut body, ref mut catch, ref mut finally)           => { body.untrack(); catch.untrack(); finally.untrack(); }
-            Stmt::While(_, ref mut expr, ref mut stmt)                           => { expr.untrack(); stmt.untrack(); }
-            Stmt::DoWhile(_, ref mut stmt, ref mut expr, ref mut semi)           => { stmt.untrack(); expr.untrack(); semi.untrack(); }
-            Stmt::For(_, ref mut init, ref mut test, ref mut incr, ref mut body) => { init.untrack(); test.untrack(); incr.untrack(); body.untrack(); }
-            Stmt::ForIn(_, ref mut lhs, ref mut rhs, ref mut body)               => { lhs.untrack(); rhs.untrack(); body.untrack(); }
-            Stmt::ForOf(_, ref mut lhs, ref mut rhs, ref mut body)               => { lhs.untrack(); rhs.untrack(); body.untrack(); }
-            Stmt::Debugger(_, ref mut semi)                                      => { semi.untrack(); }
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut, Untrack)]
 pub enum ForHead {
     Var(Option<Span>, Vec<Dtor>),
     Let(Option<Span>, Vec<Dtor>),
     Expr(Option<Span>, Expr)
 }
 
-impl Untrack for ForHead {
-    fn untrack(&mut self) {
-        match *self {
-            ForHead::Var(ref mut location, ref mut vec)
-          | ForHead::Let(ref mut location, ref mut vec) => {
-                *location = None;
-                vec.untrack();
-            }
-            ForHead::Expr(ref mut location, ref mut expr) => {
-                *location = None;
-                expr.untrack();
-            }
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut, Untrack)]
 pub enum ForInHead {
     VarInit(Option<Span>, Id, Expr),
     Var(Option<Span>, Patt<Id>),
@@ -140,77 +97,28 @@ pub enum ForInHead {
     Patt(Patt<AssignTarget>)
 }
 
-impl Untrack for ForInHead {
-    fn untrack(&mut self) {
-        match *self {
-            ForInHead::VarInit(ref mut location, ref mut id, ref mut expr) => {
-                *location = None;
-                id.untrack();
-                expr.untrack();
-            }
-            ForInHead::Var(ref mut location, ref mut patt)
-          | ForInHead::Let(ref mut location, ref mut patt) => {
-                *location = None;
-                patt.untrack();
-            }
-            ForInHead::Patt(ref mut patt) => {
-                patt.untrack();
-            }
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut, Untrack)]
 pub enum ForOfHead {
     Var(Option<Span>, Patt<Id>),
     Let(Option<Span>, Patt<Id>),
     Patt(Patt<AssignTarget>)
 }
 
-impl Untrack for ForOfHead {
-    fn untrack(&mut self) {
-        match *self {
-            ForOfHead::Var(ref mut location, ref mut patt)
-          | ForOfHead::Let(ref mut location, ref mut patt) => {
-                *location = None;
-                patt.untrack();
-            }
-            ForOfHead::Patt(ref mut patt) => { patt.untrack(); }
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut, Untrack)]
 pub struct Catch {
     pub location: Option<Span>,
     pub param: Patt<Id>,
     pub body: Vec<StmtListItem>
 }
 
-impl Untrack for Catch {
-    fn untrack(&mut self) {
-        self.location = None;
-        self.param.untrack();
-        self.body.untrack();
-    }
-}
-
-#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut, Untrack)]
 pub struct Case {
     pub location: Option<Span>,
     pub test: Option<Expr>,
     pub body: Vec<StmtListItem>
 }
 
-impl Untrack for Case {
-    fn untrack(&mut self) {
-        self.location = None;
-        self.test.untrack();
-        self.body.untrack();
-    }
-}
-
-#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut, Untrack)]
 pub struct Dir {
     pub location: Option<Span>,
     pub string: StringLiteral,
@@ -227,14 +135,7 @@ impl Dir {
     }
 }
 
-impl Untrack for Dir {
-    fn untrack(&mut self) {
-        self.location = None;
-        self.semi.untrack();
-    }
-}
-
-#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut, Untrack)]
 pub enum ModItem {
     Import(Import),
     Export(Export),
@@ -242,18 +143,7 @@ pub enum ModItem {
     Stmt(Stmt)
 }
 
-impl Untrack for ModItem {
-    fn untrack(&mut self) {
-        match *self {
-            ModItem::Import(ref mut import) => { import.untrack(); }
-            ModItem::Export(ref mut export) => { export.untrack(); }
-            ModItem::Decl(ref mut decl) => { decl.untrack(); }
-            ModItem::Stmt(ref mut stmt) => { stmt.untrack(); }
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut, Untrack)]
 pub enum StmtListItem {
     Decl(Decl),
     Stmt(Stmt)
@@ -285,15 +175,6 @@ impl StmtListItem {
         match self {
             StmtListItem::Stmt(stmt) => ModItem::Stmt(stmt),
             StmtListItem::Decl(decl) => ModItem::Decl(decl)
-        }
-    }
-}
-
-impl Untrack for StmtListItem {
-    fn untrack(&mut self) {
-        match *self {
-            StmtListItem::Decl(ref mut decl) => { decl.untrack(); }
-            StmtListItem::Stmt(ref mut stmt) => { stmt.untrack(); }
         }
     }
 }

--- a/crates/easter/src/stmt.rs
+++ b/crates/easter/src/stmt.rs
@@ -7,7 +7,7 @@ use decl::{Decl, Dtor, Import, Export};
 use patt::{Patt, AssignTarget};
 use punc::Semi;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub enum Stmt {
     Empty(Option<Span>),
     Block(Option<Span>, Vec<StmtListItem>),
@@ -30,19 +30,11 @@ pub enum Stmt {
     Debugger(Option<Span>, Semi)
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub struct Body<Item> {
     pub location: Option<Span>,
     pub dirs: Vec<Dir>,
     pub items: Vec<Item>
-}
-
-impl<Item> TrackingRef for Body<Item> {
-    fn tracking_ref(&self) -> &Option<Span> { &self.location }
-}
-
-impl<Item> TrackingMut for Body<Item> {
-    fn tracking_mut(&mut self) -> &mut Option<Span> { &mut self.location }
 }
 
 impl<Item: Untrack> Untrack for Body<Item> {
@@ -90,58 +82,6 @@ impl Stmt {
     }
 }
 
-impl TrackingRef for Stmt {
-    fn tracking_ref(&self) -> &Option<Span> {
-        match *self {
-            Stmt::Empty(ref location)
-          | Stmt::Block(ref location, _)
-          | Stmt::Var(ref location, _, _)
-          | Stmt::Expr(ref location, _, _)
-          | Stmt::If(ref location, _, _, _)
-          | Stmt::Label(ref location, _, _)
-          | Stmt::Break(ref location, _, _)
-          | Stmt::Cont(ref location, _, _)
-          | Stmt::With(ref location, _, _)
-          | Stmt::Switch(ref location, _, _)
-          | Stmt::Return(ref location, _, _)
-          | Stmt::Throw(ref location, _, _)
-          | Stmt::Try(ref location, _, _, _)
-          | Stmt::While(ref location, _, _)
-          | Stmt::DoWhile(ref location, _, _, _)
-          | Stmt::For(ref location, _, _, _, _)
-          | Stmt::ForIn(ref location, _, _, _)
-          | Stmt::ForOf(ref location, _, _, _)
-          | Stmt::Debugger(ref location, _) => location
-        }
-    }
-}
-
-impl TrackingMut for Stmt {
-    fn tracking_mut(&mut self) -> &mut Option<Span> {
-        match *self {
-            Stmt::Empty(ref mut location)
-          | Stmt::Block(ref mut location, _)
-          | Stmt::Var(ref mut location, _, _)
-          | Stmt::Expr(ref mut location, _, _)
-          | Stmt::If(ref mut location, _, _, _)
-          | Stmt::Label(ref mut location, _, _)
-          | Stmt::Break(ref mut location, _, _)
-          | Stmt::Cont(ref mut location, _, _)
-          | Stmt::With(ref mut location, _, _)
-          | Stmt::Switch(ref mut location, _, _)
-          | Stmt::Return(ref mut location, _, _)
-          | Stmt::Throw(ref mut location, _, _)
-          | Stmt::Try(ref mut location, _, _, _)
-          | Stmt::While(ref mut location, _, _)
-          | Stmt::DoWhile(ref mut location, _, _, _)
-          | Stmt::For(ref mut location, _, _, _, _)
-          | Stmt::ForIn(ref mut location, _, _, _)
-          | Stmt::ForOf(ref mut location, _, _, _)
-          | Stmt::Debugger(ref mut location, _) => location
-        }
-    }
-}
-
 impl Untrack for Stmt {
     fn untrack(&mut self) {
         *self.tracking_mut() = None;
@@ -169,31 +109,11 @@ impl Untrack for Stmt {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub enum ForHead {
     Var(Option<Span>, Vec<Dtor>),
     Let(Option<Span>, Vec<Dtor>),
     Expr(Option<Span>, Expr)
-}
-
-impl TrackingRef for ForHead {
-    fn tracking_ref(&self) -> &Option<Span> {
-        match *self {
-            ForHead::Var(ref location, _)
-          | ForHead::Let(ref location, _)
-          | ForHead::Expr(ref location, _) => location
-        }
-    }
-}
-
-impl TrackingMut for ForHead {
-    fn tracking_mut(&mut self) -> &mut Option<Span> {
-        match *self {
-            ForHead::Var(ref mut location, _)
-          | ForHead::Let(ref mut location, _)
-          | ForHead::Expr(ref mut location, _) => location
-        }
-    }
 }
 
 impl Untrack for ForHead {
@@ -212,34 +132,12 @@ impl Untrack for ForHead {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub enum ForInHead {
     VarInit(Option<Span>, Id, Expr),
     Var(Option<Span>, Patt<Id>),
     Let(Option<Span>, Patt<Id>),
     Patt(Patt<AssignTarget>)
-}
-
-impl TrackingRef for ForInHead {
-    fn tracking_ref(&self) -> &Option<Span> {
-        match *self {
-            ForInHead::VarInit(ref location, _, _)
-          | ForInHead::Var(ref location, _)
-          | ForInHead::Let(ref location, _) => location,
-            ForInHead::Patt(ref patt) => patt.tracking_ref()
-        }
-    }
-}
-
-impl TrackingMut for ForInHead {
-    fn tracking_mut(&mut self) -> &mut Option<Span> {
-        match *self {
-            ForInHead::VarInit(ref mut location, _, _)
-          | ForInHead::Var(ref mut location, _)
-          | ForInHead::Let(ref mut location, _) => location,
-            ForInHead::Patt(ref mut patt) => patt.tracking_mut()
-        }
-    }
 }
 
 impl Untrack for ForInHead {
@@ -262,31 +160,11 @@ impl Untrack for ForInHead {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub enum ForOfHead {
     Var(Option<Span>, Patt<Id>),
     Let(Option<Span>, Patt<Id>),
     Patt(Patt<AssignTarget>)
-}
-
-impl TrackingRef for ForOfHead {
-    fn tracking_ref(&self) -> &Option<Span> {
-        match *self {
-            ForOfHead::Var(ref location, _)
-          | ForOfHead::Let(ref location, _) => location,
-            ForOfHead::Patt(ref patt) => patt.tracking_ref()
-        }
-    }
-}
-
-impl TrackingMut for ForOfHead {
-    fn tracking_mut(&mut self) -> &mut Option<Span> {
-        match *self {
-            ForOfHead::Var(ref mut location, _)
-          | ForOfHead::Let(ref mut location, _) => location,
-            ForOfHead::Patt(ref mut patt) => patt.tracking_mut()
-        }
-    }
 }
 
 impl Untrack for ForOfHead {
@@ -302,19 +180,11 @@ impl Untrack for ForOfHead {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub struct Catch {
     pub location: Option<Span>,
     pub param: Patt<Id>,
     pub body: Vec<StmtListItem>
-}
-
-impl TrackingRef for Catch {
-    fn tracking_ref(&self) -> &Option<Span> { &self.location }
-}
-
-impl TrackingMut for Catch {
-    fn tracking_mut(&mut self) -> &mut Option<Span> { &mut self.location }
 }
 
 impl Untrack for Catch {
@@ -325,19 +195,11 @@ impl Untrack for Catch {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub struct Case {
     pub location: Option<Span>,
     pub test: Option<Expr>,
     pub body: Vec<StmtListItem>
-}
-
-impl TrackingRef for Case {
-    fn tracking_ref(&self) -> &Option<Span> { &self.location }
-}
-
-impl TrackingMut for Case {
-    fn tracking_mut(&mut self) -> &mut Option<Span> { &mut self.location }
 }
 
 impl Untrack for Case {
@@ -348,7 +210,7 @@ impl Untrack for Case {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub struct Dir {
     pub location: Option<Span>,
     pub string: StringLiteral,
@@ -365,14 +227,6 @@ impl Dir {
     }
 }
 
-impl TrackingRef for Dir {
-    fn tracking_ref(&self) -> &Option<Span> { &self.location }
-}
-
-impl TrackingMut for Dir {
-    fn tracking_mut(&mut self) -> &mut Option<Span> { &mut self.location }
-}
-
 impl Untrack for Dir {
     fn untrack(&mut self) {
         self.location = None;
@@ -380,34 +234,12 @@ impl Untrack for Dir {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub enum ModItem {
     Import(Import),
     Export(Export),
     Decl(Decl),
     Stmt(Stmt)
-}
-
-impl TrackingRef for ModItem {
-    fn tracking_ref(&self) -> &Option<Span> {
-        match *self {
-            ModItem::Import(ref import) => import.tracking_ref(),
-            ModItem::Export(ref export) => export.tracking_ref(),
-            ModItem::Decl(ref decl) => decl.tracking_ref(),
-            ModItem::Stmt(ref stmt) => stmt.tracking_ref()
-        }
-    }
-}
-
-impl TrackingMut for ModItem {
-    fn tracking_mut(&mut self) -> &mut Option<Span> {
-        match *self {
-            ModItem::Import(ref mut import) => import.tracking_mut(),
-            ModItem::Export(ref mut export) => export.tracking_mut(),
-            ModItem::Decl(ref mut decl) => decl.tracking_mut(),
-            ModItem::Stmt(ref mut stmt) => stmt.tracking_mut()
-        }
-    }
 }
 
 impl Untrack for ModItem {
@@ -421,7 +253,7 @@ impl Untrack for ModItem {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, TrackingRef, TrackingMut)]
 pub enum StmtListItem {
     Decl(Decl),
     Stmt(Stmt)
@@ -453,24 +285,6 @@ impl StmtListItem {
         match self {
             StmtListItem::Stmt(stmt) => ModItem::Stmt(stmt),
             StmtListItem::Decl(decl) => ModItem::Decl(decl)
-        }
-    }
-}
-
-impl TrackingRef for StmtListItem {
-    fn tracking_ref(&self) -> &Option<Span> {
-        match *self {
-            StmtListItem::Decl(ref decl) => decl.tracking_ref(),
-            StmtListItem::Stmt(ref stmt) => stmt.tracking_ref()
-        }
-    }
-}
-
-impl TrackingMut for StmtListItem {
-    fn tracking_mut(&mut self) -> &mut Option<Span> {
-        match *self {
-            StmtListItem::Decl(ref mut decl) => decl.tracking_mut(),
-            StmtListItem::Stmt(ref mut stmt) => stmt.tracking_mut()
         }
     }
 }

--- a/crates/joker/src/token.rs
+++ b/crates/joker/src/token.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::fmt::{Debug, Formatter};
-use track::{Span, Posn};
+use track::{Span, Posn, Untrack};
 use word::{Reserved, Name};
 
 #[derive(Debug, PartialEq, Clone)]
@@ -100,6 +100,10 @@ pub struct RegExpLiteral {
     pub flags: Vec<char>
 }
 
+impl Untrack for RegExpLiteral {
+    fn untrack(&mut self) {}
+}
+
 trait CharsEx {
     fn alphabetize(&self) -> Vec<char>;
 }
@@ -134,6 +138,10 @@ pub struct StringLiteral {
     pub value: String
 }
 
+impl Untrack for StringLiteral {
+    fn untrack(&mut self) {}
+}
+
 impl Debug for StringLiteral {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
         fmt.debug_struct("StringLiteral")
@@ -152,6 +160,10 @@ impl PartialEq for StringLiteral {
 pub struct NumberLiteral {
     pub source: Option<NumberSource>,
     pub value: f64
+}
+
+impl Untrack for NumberLiteral {
+    fn untrack(&mut self) {}
 }
 
 impl Debug for NumberLiteral {

--- a/crates/joker/src/track.rs
+++ b/crates/joker/src/track.rs
@@ -78,6 +78,12 @@ impl<T> Untrack for Option<T>
     }
 }
 
+impl Untrack for Option<Span> {
+    fn untrack(&mut self) {
+        *self = None;
+    }
+}
+
 impl<T> Untrack for Vec<T>
   where T: Untrack
 {


### PR DESCRIPTION
Basically reopen of #29, but with solved issue of error locations during development.

Now, during development you can use nightly version of Rust and run tests with `cargo test --features nightly` (Travis script updated correspondingly) which will use native custom derives, so expand in-place and any syntactic errors will be reported in correct locations.

On the other hand, when running `cargo build` / `cargo test` on stable Rust, everything will still work, but this time via build script that transpiles sources which is not very convenient for development but preserves backward compatibility and allows crate to be used and tested on stable Rust.