### PR TITLE
Remove unnecessary mut

### DIFF
--- a/benches/parser-bench.rs
+++ b/benches/parser-bench.rs
@@ -119,7 +119,7 @@ fn integration_tests(target: &mut Vec<TestDescAndFn>, ignore: bool, stack_size: 
         .collect::<Vec<_>>();
 
     for (name, source, expected_ast) in tests {
-        add_bench(target, name, false, move |mut bench| {
+        add_bench(target, name, false, move |bench| {
             let mut result = None;
             bench.iter(|| {
                 result = Some(script(&source[..]))


### PR DESCRIPTION
Prevents the following warning currently in master:

```
warning: variable does not need to be mutable
   --> benches/parser-bench.rs:122:46
    |
122 |         add_bench(target, name, false, move |mut bench| {
    |                                              ^^^^^^^^^
    |
    = note: #[warn(unused_mut)] on by default
```