### PR TITLE
Expr::New - Some(empty args) is equivalent to None

### DIFF
--- a/crates/estree/src/expr.rs
+++ b/crates/estree/src/expr.rs
@@ -101,7 +101,7 @@ impl IntoExpr for Object {
             Tag::NewExpression => {
                 let callee = Box::new(self.extract_expr("callee")?);
                 let args = self.extract_expr_list("arguments")?;
-                Expr::New(None, callee, Some(args))
+                Expr::New(None, callee, args)
             }
             Tag::ArrayExpression => {
                 let elts = self.extract_expr_opt_list("elements")?;

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -49,7 +49,7 @@ impl Arguments {
     }
 
     pub fn append_to_new(self, new: Token, expr: Expr) -> Expr {
-        Expr::New(span(&Some(new.location), &Some(self.end.location)), Box::new(expr), Some(self.args))
+        Expr::New(span(&Some(new.location), &Some(self.end.location)), Box::new(expr), self.args)
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1391,7 +1391,7 @@ impl<I: Iterator<Item=char>> Parser<I> {
                 self.arguments()?.append_to_new(new, base)
             } else {
                 let location = span(&Some(new.location), &base);
-                Expr::New(location, Box::new(base), None)
+                Expr::New(location, Box::new(base), vec![])
             };
         }
         self.more_suffixes(base)


### PR DESCRIPTION
Based on the [PartialEq implementation](https://github.com/dherman/esprit/blob/9af10f7c51df6a31123549153eca8b4177cf549f/crates/easter/src/expr.rs#L78-L81) for `Expr`, a New variant with an empty list of args is equivalent to a New variant with no args list (`None`). Since initializing an empty vec [does no allocation](https://doc.rust-lang.org/std/vec/struct.Vec.html#guarantees), we can just use the equivalent representation and remove the `Option` altogether.

Further, we can remove the custom implementaion of PartialEq since this is the only thing that isn't equivalent.

Sound good?