### PR TITLE
Utilize bencher.bytes

### DIFF
--- a/benches/parser-bench.rs
+++ b/benches/parser-bench.rs
@@ -121,6 +121,7 @@ fn integration_tests(target: &mut Vec<TestDescAndFn>, ignore: bool, stack_size: 
     for (name, source, expected_ast) in tests {
         add_bench(target, name, false, move |bench| {
             let mut result = None;
+            bench.bytes = source.len() as _;
             bench.iter(|| {
                 result = Some(script(&source[..]))
             });


### PR DESCRIPTION
Bencher has a byte field to show human-readable result.

## After:
```
test tests/esprima/test/3rdparty/angular-1.2.5.js       ... bench:  52,084,030 ns/iter (+/- 4,262,784) = 13 MB/s
test tests/esprima/test/3rdparty/backbone-1.1.0.js      ... bench:   7,268,387 ns/iter (+/- 258,704) = 8 MB/s
test tests/esprima/test/3rdparty/jquery-1.9.1.js        ... bench:  39,075,084 ns/iter (+/- 1,703,307) = 6 MB/s
test tests/esprima/test/3rdparty/jquery.mobile-1.4.2.js ... bench:  60,086,882 ns/iter (+/- 3,785,594) = 7 MB/s
test tests/esprima/test/3rdparty/mootools-1.4.5.js      ... bench:  31,113,994 ns/iter (+/- 2,294,243) = 5 MB/s
test tests/esprima/test/3rdparty/underscore-1.5.2.js    ... bench:   6,182,302 ns/iter (+/- 644,659) = 7 MB/s
test tests/esprima/test/3rdparty/yui-3.12.0.js          ... bench:  29,845,808 ns/iter (+/- 3,936,079) = 11 MB/s
```
